### PR TITLE
Use clang-format to format source code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,124 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:         true
+  AfterClass:             true
+  AfterControlStatement:  true
+  AfterEnum:              true
+  AfterFunction:          true
+  AfterNamespace:         true
+  AfterStruct:            true
+  AfterUnion:             true
+  AfterExternBlock:       false
+  BeforeCatch:            true
+  BeforeElse:             true
+  IndentBraces:           false
+  SplitEmptyFunction:     true
+  SplitEmptyRecord:       true
+  SplitEmptyNamespace:    true
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakConstructorInitializersBeforeComma: false
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 4
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 4
+UseTab: Never
+...

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/EWARM/**/Exe/
 **/EWARM/**/List/
 **/EWARM/**/Obj/
+*.pyc

--- a/lib/stm32-bootloader/bootloader.c
+++ b/lib/stm32-bootloader/bootloader.c
@@ -1,39 +1,40 @@
 /**
-  ******************************************************************************
-  * STM32 Bootloader Source
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   bootloader.c
-  * @brief  This file contains the functions of the bootloader. The bootloader
-  *	        implementation uses the official HAL library of ST.
-  * @see    Please refer to README for detailed information.
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32 Bootloader Source
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   bootloader.c
+ * @brief  This file contains the functions of the bootloader. The bootloader
+ *	       implementation uses the official HAL library of ST.
+ *
+ * @see    Please refer to README for detailed information.
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
 #include "bootloader.h"
 
 /* Private defines -----------------------------------------------------------*/
-#define BOOTLOADER_VERSION_MAJOR    1       /*!< Major version */
-#define BOOTLOADER_VERSION_MINOR    1       /*!< Minor version */
-#define BOOTLOADER_VERSION_PATCH    0       /*!< Patch version */
-#define BOOTLOADER_VERSION_RC       0       /*!< Release candidate version */
+#define BOOTLOADER_VERSION_MAJOR 1 /*!< Major version */
+#define BOOTLOADER_VERSION_MINOR 1 /*!< Minor version */
+#define BOOTLOADER_VERSION_PATCH 0 /*!< Patch version */
+#define BOOTLOADER_VERSION_RC    0 /*!< Release candidate version */
 
 /* Private typedef -----------------------------------------------------------*/
-typedef void (*pFunction)(void);            /*!< Function pointer definition */
+typedef void (*pFunction)(void); /*!< Function pointer definition */
 
 /* Private variables ---------------------------------------------------------*/
-static uint32_t flash_ptr = APP_ADDRESS;    /*!< Private variable for tracking flashing progress */
-
+/** Private variable for tracking flashing progress */
+static uint32_t flash_ptr = APP_ADDRESS;
 
 /**
-  * @brief  This function initializes bootloader and flash.
-  * @param  None
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK is returned in every case
-*/
+ * @brief  This function initializes bootloader and flash.
+ * @param  None
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK is returned in every case
+ */
 uint8_t Bootloader_Init(void)
 {
     __HAL_RCC_SYSCFG_CLK_ENABLE();
@@ -48,18 +49,18 @@ uint8_t Bootloader_Init(void)
 }
 
 /**
-  * @brief  This function erases the user application area in flash
-  * @param  None
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK: upon success
-  * @retval BL_ERR: upon failure
-*/
+ * @brief  This function erases the user application area in flash
+ * @param  None
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK: upon success
+ * @retval BL_ERR: upon failure
+ */
 uint8_t Bootloader_Erase(void)
 {
-    uint32_t NbrOfPages = 0;
-    uint32_t PageError  = 0;
-    FLASH_EraseInitTypeDef  pEraseInit;
-    HAL_StatusTypeDef       status = HAL_OK;
+    uint32_t               NbrOfPages = 0;
+    uint32_t               PageError  = 0;
+    FLASH_EraseInitTypeDef pEraseInit;
+    HAL_StatusTypeDef      status = HAL_OK;
 
     HAL_FLASH_Unlock();
 
@@ -68,22 +69,22 @@ uint8_t Bootloader_Erase(void)
 
     if(NbrOfPages > FLASH_PAGE_NBPERBANK)
     {
-        pEraseInit.Banks = FLASH_BANK_1;
-        pEraseInit.NbPages = NbrOfPages % FLASH_PAGE_NBPERBANK;
-        pEraseInit.Page = FLASH_PAGE_NBPERBANK - pEraseInit.NbPages;
+        pEraseInit.Banks     = FLASH_BANK_1;
+        pEraseInit.NbPages   = NbrOfPages % FLASH_PAGE_NBPERBANK;
+        pEraseInit.Page      = FLASH_PAGE_NBPERBANK - pEraseInit.NbPages;
         pEraseInit.TypeErase = FLASH_TYPEERASE_PAGES;
-        status = HAL_FLASHEx_Erase(&pEraseInit, &PageError);
+        status               = HAL_FLASHEx_Erase(&pEraseInit, &PageError);
 
         NbrOfPages = FLASH_PAGE_NBPERBANK;
     }
 
     if(status == HAL_OK)
     {
-        pEraseInit.Banks = FLASH_BANK_2;
-        pEraseInit.NbPages = NbrOfPages;
-        pEraseInit.Page = FLASH_PAGE_NBPERBANK - pEraseInit.NbPages;
+        pEraseInit.Banks     = FLASH_BANK_2;
+        pEraseInit.NbPages   = NbrOfPages;
+        pEraseInit.Page      = FLASH_PAGE_NBPERBANK - pEraseInit.NbPages;
         pEraseInit.TypeErase = FLASH_TYPEERASE_PAGES;
-        status = HAL_FLASHEx_Erase(&pEraseInit, &PageError);
+        status               = HAL_FLASHEx_Erase(&pEraseInit, &PageError);
     }
 
     HAL_FLASH_Lock();
@@ -92,12 +93,12 @@ uint8_t Bootloader_Erase(void)
 }
 
 /**
-  * @brief  Begin flash programming: this function unlocks the flash and sets
-  *         the data pointer to the start of application flash area.
-  * @see    README for futher information
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK is returned in every case
-*/
+ * @brief  Begin flash programming: this function unlocks the flash and sets
+ *         the data pointer to the start of application flash area.
+ * @see    README for futher information
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK is returned in every case
+ */
 uint8_t Bootloader_FlashBegin(void)
 {
     /* Reset flash destination address */
@@ -110,23 +111,25 @@ uint8_t Bootloader_FlashBegin(void)
 }
 
 /**
-  * @brief  Program 64bit data into flash: this function writes an 8byte (64bit)
-  *         data chunk into the flash and increments the data pointer.
-  * @see    README for futher information
-  * @param  data: 64bit data chunk to be written into flash
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK: upon success
-  * @retval BL_WRITE_ERROR: upon failure
-*/
+ * @brief  Program 64bit data into flash: this function writes an 8byte (64bit)
+ *         data chunk into the flash and increments the data pointer.
+ * @see    README for futher information
+ * @param  data: 64bit data chunk to be written into flash
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK: upon success
+ * @retval BL_WRITE_ERROR: upon failure
+ */
 uint8_t Bootloader_FlashNext(uint64_t data)
 {
-    if( !(flash_ptr <= (FLASH_BASE + FLASH_SIZE - 8)) || (flash_ptr < APP_ADDRESS) )
+    if(!(flash_ptr <= (FLASH_BASE + FLASH_SIZE - 8)) ||
+       (flash_ptr < APP_ADDRESS))
     {
         HAL_FLASH_Lock();
         return BL_WRITE_ERROR;
     }
 
-    if(HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, flash_ptr, data) == HAL_OK)
+    if(HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, flash_ptr, data) ==
+       HAL_OK)
     {
         /* Check the written value */
         if(*(uint64_t*)flash_ptr != data)
@@ -149,13 +152,13 @@ uint8_t Bootloader_FlashNext(uint64_t data)
 }
 
 /**
-  * @brief  Finish flash programming: this function finalizes the flash
-  *         programming by locking the flash.
-  * @see    README for futher information
-  * @param  None
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK is returned in every case
-*/
+ * @brief  Finish flash programming: this function finalizes the flash
+ *         programming by locking the flash.
+ * @see    README for futher information
+ * @param  None
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK is returned in every case
+ */
 uint8_t Bootloader_FlashEnd(void)
 {
     /* Lock flash */
@@ -165,20 +168,20 @@ uint8_t Bootloader_FlashEnd(void)
 }
 
 /**
-  * @brief  This function returns the protection status of flash.
-  * @param  None
-  * @return Flash protection status ::eFlashProtectionTypes
-*/
+ * @brief  This function returns the protection status of flash.
+ * @param  None
+ * @return Flash protection status ::eFlashProtectionTypes
+ */
 uint8_t Bootloader_GetProtectionStatus(void)
 {
-    FLASH_OBProgramInitTypeDef OBStruct = {0};
-    uint8_t protection = BL_PROTECTION_NONE;
+    FLASH_OBProgramInitTypeDef OBStruct   = {0};
+    uint8_t                    protection = BL_PROTECTION_NONE;
 
     HAL_FLASH_Unlock();
 
     /* Bank 1 */
     OBStruct.PCROPConfig = FLASH_BANK_1;
-    OBStruct.WRPArea = OB_WRPAREA_BANK1_AREAA;
+    OBStruct.WRPArea     = OB_WRPAREA_BANK1_AREAA;
     HAL_FLASHEx_OBGetConfig(&OBStruct);
     /* PCROP */
     if(OBStruct.PCROPEndAddr > OBStruct.PCROPStartAddr)
@@ -191,7 +194,8 @@ uint8_t Bootloader_GetProtectionStatus(void)
     /* WRP Area_A */
     if(OBStruct.WRPEndOffset > OBStruct.WRPStartOffset)
     {
-        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE) >= APP_ADDRESS)
+        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE) >=
+           APP_ADDRESS)
         {
             protection |= BL_PROTECTION_WRP;
         }
@@ -202,7 +206,8 @@ uint8_t Bootloader_GetProtectionStatus(void)
     /* WRP Area_B */
     if(OBStruct.WRPEndOffset > OBStruct.WRPStartOffset)
     {
-        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE) >= APP_ADDRESS)
+        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE) >=
+           APP_ADDRESS)
         {
             protection |= BL_PROTECTION_WRP;
         }
@@ -210,7 +215,7 @@ uint8_t Bootloader_GetProtectionStatus(void)
 
     /* Bank 2 */
     OBStruct.PCROPConfig = FLASH_BANK_2;
-    OBStruct.WRPArea = OB_WRPAREA_BANK2_AREAA;
+    OBStruct.WRPArea     = OB_WRPAREA_BANK2_AREAA;
     HAL_FLASHEx_OBGetConfig(&OBStruct);
     /* PCROP */
     if(OBStruct.PCROPEndAddr > OBStruct.PCROPStartAddr)
@@ -223,7 +228,8 @@ uint8_t Bootloader_GetProtectionStatus(void)
     /* WRP Area_A */
     if(OBStruct.WRPEndOffset > OBStruct.WRPStartOffset)
     {
-        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE + FLASH_PAGE_SIZE * FLASH_PAGE_NBPERBANK) >= APP_ADDRESS)
+        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE +
+            FLASH_PAGE_SIZE * FLASH_PAGE_NBPERBANK) >= APP_ADDRESS)
         {
             protection |= BL_PROTECTION_WRP;
         }
@@ -234,7 +240,8 @@ uint8_t Bootloader_GetProtectionStatus(void)
     /* WRP Area_B */
     if(OBStruct.WRPEndOffset > OBStruct.WRPStartOffset)
     {
-        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE + FLASH_PAGE_SIZE * FLASH_PAGE_NBPERBANK) >= APP_ADDRESS)
+        if((OBStruct.WRPStartOffset * FLASH_PAGE_SIZE + FLASH_BASE +
+            FLASH_PAGE_SIZE * FLASH_PAGE_NBPERBANK) >= APP_ADDRESS)
         {
             protection |= BL_PROTECTION_WRP;
         }
@@ -251,66 +258,66 @@ uint8_t Bootloader_GetProtectionStatus(void)
 }
 
 /**
-  * @brief  This function configures the wirte protection of flash.
-  * @param  protection: protection type ::eFlashProtectionTypes
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK: upon success
-  * @retval BL_OBP_ERROR: upon failure
-*/
+ * @brief  This function configures the wirte protection of flash.
+ * @param  protection: protection type ::eFlashProtectionTypes
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK: upon success
+ * @retval BL_OBP_ERROR: upon failure
+ */
 uint8_t Bootloader_ConfigProtection(uint32_t protection)
 {
-    FLASH_OBProgramInitTypeDef  OBStruct = {0};
-    HAL_StatusTypeDef           status = HAL_ERROR;
+    FLASH_OBProgramInitTypeDef OBStruct = {0};
+    HAL_StatusTypeDef          status   = HAL_ERROR;
 
     status = HAL_FLASH_Unlock();
     status |= HAL_FLASH_OB_Unlock();
 
     /* Bank 1 */
-    OBStruct.WRPArea = OB_WRPAREA_BANK1_AREAA;
+    OBStruct.WRPArea    = OB_WRPAREA_BANK1_AREAA;
     OBStruct.OptionType = OPTIONBYTE_WRP;
     if(protection & BL_PROTECTION_WRP)
     {
         /* Enable WRP protection for application space */
         OBStruct.WRPStartOffset = (APP_ADDRESS - FLASH_BASE) / FLASH_PAGE_SIZE;
-        OBStruct.WRPEndOffset = FLASH_PAGE_NBPERBANK - 1;
+        OBStruct.WRPEndOffset   = FLASH_PAGE_NBPERBANK - 1;
     }
     else
     {
         /* Remove WRP protection */
         OBStruct.WRPStartOffset = 0xFF;
-        OBStruct.WRPEndOffset = 0x00;
+        OBStruct.WRPEndOffset   = 0x00;
     }
     status |= HAL_FLASHEx_OBProgram(&OBStruct);
 
     /* Area B is not used */
-    OBStruct.WRPArea = OB_WRPAREA_BANK1_AREAB;
-    OBStruct.OptionType = OPTIONBYTE_WRP;
+    OBStruct.WRPArea        = OB_WRPAREA_BANK1_AREAB;
+    OBStruct.OptionType     = OPTIONBYTE_WRP;
     OBStruct.WRPStartOffset = 0xFF;
-    OBStruct.WRPEndOffset = 0x00;
+    OBStruct.WRPEndOffset   = 0x00;
     status |= HAL_FLASHEx_OBProgram(&OBStruct);
 
     /* Bank 2 */
-    OBStruct.WRPArea = OB_WRPAREA_BANK2_AREAA;
+    OBStruct.WRPArea    = OB_WRPAREA_BANK2_AREAA;
     OBStruct.OptionType = OPTIONBYTE_WRP;
     if(protection & BL_PROTECTION_WRP)
     {
-         /* Enable WRP protection for application space */
+        /* Enable WRP protection for application space */
         OBStruct.WRPStartOffset = 0x00;
-        OBStruct.WRPEndOffset = FLASH_PAGE_NBPERBANK - 1;
+        OBStruct.WRPEndOffset   = FLASH_PAGE_NBPERBANK - 1;
     }
     else
     {
         /* Remove WRP protection */
         OBStruct.WRPStartOffset = 0xFF;
-        OBStruct.WRPEndOffset = 0x00;
+        OBStruct.WRPEndOffset   = 0x00;
     }
     status |= HAL_FLASHEx_OBProgram(&OBStruct);
 
     /* Area B is not used */
-    OBStruct.WRPArea = OB_WRPAREA_BANK2_AREAB;
-    OBStruct.OptionType = OPTIONBYTE_WRP;
+    OBStruct.WRPArea        = OB_WRPAREA_BANK2_AREAB;
+    OBStruct.OptionType     = OPTIONBYTE_WRP;
     OBStruct.WRPStartOffset = 0xFF;
-    OBStruct.WRPEndOffset = 0x00;
+    OBStruct.WRPEndOffset   = 0x00;
     status |= HAL_FLASHEx_OBProgram(&OBStruct);
 
     if(status == HAL_OK)
@@ -326,35 +333,36 @@ uint8_t Bootloader_ConfigProtection(uint32_t protection)
 }
 
 /**
-  * @brief  This function checks whether the new application fits into flash.
-  * @param  appsize: size of application
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK: if application fits into flash
-  * @retval BL_SIZE_ERROR: if application does not fit into flash
-*/
+ * @brief  This function checks whether the new application fits into flash.
+ * @param  appsize: size of application
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK: if application fits into flash
+ * @retval BL_SIZE_ERROR: if application does not fit into flash
+ */
 uint8_t Bootloader_CheckSize(uint32_t appsize)
 {
-    return ((FLASH_BASE + FLASH_SIZE - APP_ADDRESS) >= appsize) ? BL_OK : BL_SIZE_ERROR;
+    return ((FLASH_BASE + FLASH_SIZE - APP_ADDRESS) >= appsize) ? BL_OK
+                                                                : BL_SIZE_ERROR;
 }
 
 /**
-  * @brief  This function verifies the checksum of application located in flash.
-  *         If ::USE_CHECKSUM configuration parameter is disabled then the
-  *         function always returns an error code.
-  * @param  None
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK: if calculated checksum matches the application checksum
-  * @retval BL_CHKS_ERROR: upon checksum mismatch or when ::USE_CHECKSUM is
-  *         disabled
-*/
+ * @brief  This function verifies the checksum of application located in flash.
+ *         If ::USE_CHECKSUM configuration parameter is disabled then the
+ *         function always returns an error code.
+ * @param  None
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK: if calculated checksum matches the application checksum
+ * @retval BL_CHKS_ERROR: upon checksum mismatch or when ::USE_CHECKSUM is
+ *         disabled
+ */
 uint8_t Bootloader_VerifyChecksum(void)
 {
-#if (USE_CHECKSUM)
+#if(USE_CHECKSUM)
     CRC_HandleTypeDef CrcHandle;
     volatile uint32_t calculatedCrc = 0;
 
     __HAL_RCC_CRC_CLK_ENABLE();
-    CrcHandle.Instance = CRC;
+    CrcHandle.Instance                     = CRC;
     CrcHandle.Init.DefaultPolynomialUse    = DEFAULT_POLYNOMIAL_ENABLE;
     CrcHandle.Init.DefaultInitValueUse     = DEFAULT_INIT_VALUE_ENABLE;
     CrcHandle.Init.InputDataInversionMode  = CRC_INPUTDATA_INVERSION_NONE;
@@ -365,12 +373,13 @@ uint8_t Bootloader_VerifyChecksum(void)
         return BL_CHKS_ERROR;
     }
 
-    calculatedCrc = HAL_CRC_Calculate(&CrcHandle, (uint32_t*)APP_ADDRESS, APP_SIZE);
+    calculatedCrc =
+        HAL_CRC_Calculate(&CrcHandle, (uint32_t*)APP_ADDRESS, APP_SIZE);
 
     __HAL_RCC_CRC_FORCE_RESET();
     __HAL_RCC_CRC_RELEASE_RESET();
 
-    if( (*(uint32_t*)CRC_ADDRESS) == calculatedCrc )
+    if((*(uint32_t*)CRC_ADDRESS) == calculatedCrc)
     {
         return BL_OK;
     }
@@ -379,36 +388,37 @@ uint8_t Bootloader_VerifyChecksum(void)
 }
 
 /**
-  * @brief  This function checks whether a valid application exists in flash.
-  *         The check is performed by checking the very first DWORD (4 bytes) of
-  *         the application firmware. In case of a valid application, this DWORD
-  *         must represent the initialization location of stack pointer - which
-  *         must be within the boundaries of RAM.
-  * @param  None
-  * @return Bootloader error code ::eBootloaderErrorCodes
-  * @retval BL_OK: if first DWORD represents a valid stack pointer location
-  * @retval BL_NO_APP: first DWORD value is out of RAM boundaries
-*/
+ * @brief  This function checks whether a valid application exists in flash.
+ *         The check is performed by checking the very first DWORD (4 bytes) of
+ *         the application firmware. In case of a valid application, this DWORD
+ *         must represent the initialization location of stack pointer - which
+ *         must be within the boundaries of RAM.
+ * @param  None
+ * @return Bootloader error code ::eBootloaderErrorCodes
+ * @retval BL_OK: if first DWORD represents a valid stack pointer location
+ * @retval BL_NO_APP: first DWORD value is out of RAM boundaries
+ */
 uint8_t Bootloader_CheckForApplication(void)
 {
-    return (((*(uint32_t*)APP_ADDRESS) - RAM_BASE) < RAM_SIZE) ? BL_OK : BL_NO_APP;
+    return (((*(uint32_t*)APP_ADDRESS) - RAM_BASE) < RAM_SIZE) ? BL_OK
+                                                               : BL_NO_APP;
 }
 
 /**
-  * @brief  This function performs the jump to the user application in flash.
-  * @details The function carries out the following operations:
-  *  - De-initialize the clock and peripheral configuration
-  *  - Stop the systick
-  *  - Set the vector table location (if ::SET_VECTOR_TABLE is enabled)
-  *  - Sets the stack pointer location
-  *  - Perform the jump
-  * @param  None
-  * @retval None
-*/
+ * @brief  This function performs the jump to the user application in flash.
+ * @details The function carries out the following operations:
+ *  - De-initialize the clock and peripheral configuration
+ *  - Stop the systick
+ *  - Set the vector table location (if ::SET_VECTOR_TABLE is enabled)
+ *  - Sets the stack pointer location
+ *  - Perform the jump
+ * @param  None
+ * @retval None
+ */
 void Bootloader_JumpToApplication(void)
 {
     uint32_t  JumpAddress = *(__IO uint32_t*)(APP_ADDRESS + 4);
-    pFunction Jump = (pFunction)JumpAddress;
+    pFunction Jump        = (pFunction)JumpAddress;
 
     HAL_RCC_DeInit();
     HAL_DeInit();
@@ -417,7 +427,7 @@ void Bootloader_JumpToApplication(void)
     SysTick->LOAD = 0;
     SysTick->VAL  = 0;
 
-#if (SET_VECTOR_TABLE)
+#if(SET_VECTOR_TABLE)
     SCB->VTOR = APP_ADDRESS;
 #endif
 
@@ -426,20 +436,20 @@ void Bootloader_JumpToApplication(void)
 }
 
 /**
-  * @brief  This function performs the jump to the MCU System Memory (ST
-  *         Bootloader).
-  * @details The function carries out the following operations:
-  *  - De-initialize the clock and peripheral configuration
-  *  - Stop the systick
-  *  - Remap the system flash memory
-  *  - Perform the jump
-  * @param  None
-  * @retval None
-*/
+ * @brief  This function performs the jump to the MCU System Memory (ST
+ *         Bootloader).
+ * @details The function carries out the following operations:
+ *  - De-initialize the clock and peripheral configuration
+ *  - Stop the systick
+ *  - Remap the system flash memory
+ *  - Perform the jump
+ * @param  None
+ * @retval None
+ */
 void Bootloader_JumpToSysMem(void)
 {
     uint32_t  JumpAddress = *(__IO uint32_t*)(SYSMEM_ADDRESS + 4);
-    pFunction Jump = (pFunction)JumpAddress;
+    pFunction Jump        = (pFunction)JumpAddress;
 
     HAL_RCC_DeInit();
     HAL_DeInit();
@@ -454,24 +464,24 @@ void Bootloader_JumpToSysMem(void)
     __set_MSP(*(__IO uint32_t*)SYSMEM_ADDRESS);
     Jump();
 
-    while(1);
+    while(1)
+        ;
 }
 
 /**
-  * @brief  This function returns the version number of the bootloader library.
-  *         Semantic versioning is used for numbering.
-  * @see    Semantic versioning: https://semver.org
-  * @param  None
-  * @return Bootloader version number combined into an uint32_t:
-  *          - [31:24] Major version
-  *          - [23:16] Minor version
-  *          - [15:8]  Patch version
-  *          - [7:0]   Release candidate version
-*/
+ * @brief  This function returns the version number of the bootloader library.
+ *         Semantic versioning is used for numbering.
+ * @see    Semantic versioning: https://semver.org
+ * @param  None
+ * @return Bootloader version number combined into an uint32_t:
+ *          - [31:24] Major version
+ *          - [23:16] Minor version
+ *          - [15:8]  Patch version
+ *          - [7:0]   Release candidate version
+ */
 uint32_t Bootloader_GetVersion(void)
 {
     return ((BOOTLOADER_VERSION_MAJOR << 24) |
-            (BOOTLOADER_VERSION_MINOR << 16) |
-            (BOOTLOADER_VERSION_PATCH << 8)  |
+            (BOOTLOADER_VERSION_MINOR << 16) | (BOOTLOADER_VERSION_PATCH << 8) |
             (BOOTLOADER_VERSION_RC));
 }

--- a/lib/stm32-bootloader/bootloader.h
+++ b/lib/stm32-bootloader/bootloader.h
@@ -1,117 +1,120 @@
 /**
-  ******************************************************************************
-  * STM32 Bootloader Header
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   bootloader.h
-  * @brief  This file contains the bootloader configuration parameters,
-  *	        function prototypes and other required macros and definitions.
-  * @see    Please refer to README for detailed information.
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32 Bootloader Header
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   bootloader.h
+ * @brief  This file contains the bootloader configuration parameters,
+ *	       function prototypes and other required macros and definitions.
+ *
+ * @see    Please refer to README for detailed information.
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 #ifndef __BOOTLOADER_H
 #define __BOOTLOADER_H
 
 /** Bootloader Configuration
-  * @defgroup Bootloader_Configuration
-  * @{
-  */
+ * @defgroup Bootloader_Configuration
+ * @{
+ */
 
 /** Select target MCU family: please define the target MCU family type below.
-  * Currently supported MCU families:
-  *  - STM32L4
-*/
+ * Currently supported MCU families:
+ *  - STM32L4
+ */
 #define STM32L4
 
 /** Check application checksum on startup */
-#define USE_CHECKSUM            0
+#define USE_CHECKSUM 0
 
 /** Enable write protection after performing in-app-programming */
-#define USE_WRITE_PROTECTION    0
+#define USE_WRITE_PROTECTION 0
 
 /** Automatically set vector table location before launching application */
-#define SET_VECTOR_TABLE        1
+#define SET_VECTOR_TABLE 1
 
 /** Clear reset flags
-  *  - If enabled: bootloader clears reset flags. (This occurs only when OBL RST flag is active.)
-  *  - If disabled: bootloader does not clear reset flags, not even when OBL RST is active.
-*/
-#define CLEAR_RESET_FLAGS       1
+ *  - If enabled: bootloader clears reset flags. (This occurs only when OBL RST
+ * flag is active.)
+ *  - If disabled: bootloader does not clear reset flags, not even when OBL RST
+ * is active.
+ */
+#define CLEAR_RESET_FLAGS 1
 
 /** Start address of application space in flash */
-#define APP_ADDRESS             (uint32_t)0x08008000
+#define APP_ADDRESS (uint32_t)0x08008000
 
 /** End address of application space (address of last byte) */
-#define END_ADDRESS             (uint32_t)0x080FFFFB
+#define END_ADDRESS (uint32_t)0x080FFFFB
 
 /** Start address of application checksum in flash */
-#define CRC_ADDRESS             (uint32_t)0x080FFFFC
+#define CRC_ADDRESS (uint32_t)0x080FFFFC
 
 /** Address of System Memory (ST Bootloader) */
-#define SYSMEM_ADDRESS          (uint32_t)0x1FFF0000
+#define SYSMEM_ADDRESS (uint32_t)0x1FFF0000
 /** @} */
 /* End of configuration ------------------------------------------------------*/
 
 /* Includes ------------------------------------------------------------------*/
 /* Include the appropriate header file */
-#if defined (STM32L4)
- #include "stm32l4xx.h"
+#if defined(STM32L4)
+#include "stm32l4xx.h"
 #else
- #error "Target MCU header file is not defined or unsupported."
+#error "Target MCU header file is not defined or unsupported."
 #endif
 
 /* Defines -------------------------------------------------------------------*/
 /** Size of application in DWORD (32bits or 4bytes) */
-#define APP_SIZE                (uint32_t)(((END_ADDRESS - APP_ADDRESS) + 3) / 4)
+#define APP_SIZE (uint32_t)(((END_ADDRESS - APP_ADDRESS) + 3) / 4)
 
 /** Number of pages per bank in flash */
-#define FLASH_PAGE_NBPERBANK    (256)
+#define FLASH_PAGE_NBPERBANK (256)
 
 /* MCU RAM information (to check whether flash contains valid application) */
-#define RAM_BASE                SRAM1_BASE          /*!< Start address of RAM */
-#define RAM_SIZE                SRAM1_SIZE_MAX      /*!< RAM size in bytes */
+#define RAM_BASE SRAM1_BASE     /*!< Start address of RAM */
+#define RAM_SIZE SRAM1_SIZE_MAX /*!< RAM size in bytes */
 
 /* Enumerations --------------------------------------------------------------*/
 /** Bootloader error codes */
 enum eBootloaderErrorCodes
 {
-    BL_OK = 0,          /*!< No error */
-    BL_NO_APP,          /*!< No application found in flash */
-    BL_SIZE_ERROR,      /*!< New application is too large for flash */
-    BL_CHKS_ERROR,      /*!< Application checksum error */
-    BL_ERASE_ERROR,     /*!< Flash erase error */
-    BL_WRITE_ERROR,     /*!< Flash write error */
-    BL_OBP_ERROR        /*!< Flash option bytes programming error */
+    BL_OK = 0,      /*!< No error */
+    BL_NO_APP,      /*!< No application found in flash */
+    BL_SIZE_ERROR,  /*!< New application is too large for flash */
+    BL_CHKS_ERROR,  /*!< Application checksum error */
+    BL_ERASE_ERROR, /*!< Flash erase error */
+    BL_WRITE_ERROR, /*!< Flash write error */
+    BL_OBP_ERROR    /*!< Flash option bytes programming error */
 };
 
 /** Flash Protection Types */
 enum eFlashProtectionTypes
 {
-    BL_PROTECTION_NONE  = 0,    /*!< No flash protection */
-    BL_PROTECTION_WRP   = 0x1,  /*!< Flash write protection */
-    BL_PROTECTION_RDP   = 0x2,  /*!< Flash read protection */
-    BL_PROTECTION_PCROP = 0x4,  /*!< Flash propietary code readout protection */
+    BL_PROTECTION_NONE  = 0,   /*!< No flash protection */
+    BL_PROTECTION_WRP   = 0x1, /*!< Flash write protection */
+    BL_PROTECTION_RDP   = 0x2, /*!< Flash read protection */
+    BL_PROTECTION_PCROP = 0x4, /*!< Flash propietary code readout protection */
 };
 
 /* Functions -----------------------------------------------------------------*/
-uint8_t  Bootloader_Init(void);
-uint8_t  Bootloader_Erase(void);
+uint8_t Bootloader_Init(void);
+uint8_t Bootloader_Erase(void);
 
-uint8_t  Bootloader_FlashBegin(void);
-uint8_t  Bootloader_FlashNext(uint64_t data);
-uint8_t  Bootloader_FlashEnd(void);
+uint8_t Bootloader_FlashBegin(void);
+uint8_t Bootloader_FlashNext(uint64_t data);
+uint8_t Bootloader_FlashEnd(void);
 
-uint8_t  Bootloader_GetProtectionStatus(void);
-uint8_t  Bootloader_ConfigProtection(uint32_t protection);
+uint8_t Bootloader_GetProtectionStatus(void);
+uint8_t Bootloader_ConfigProtection(uint32_t protection);
 
-uint8_t  Bootloader_CheckSize(uint32_t appsize);
-uint8_t  Bootloader_VerifyChecksum(void);
-uint8_t  Bootloader_CheckForApplication(void);
-void     Bootloader_JumpToApplication(void);
-void     Bootloader_JumpToSysMem(void);
+uint8_t Bootloader_CheckSize(uint32_t appsize);
+uint8_t Bootloader_VerifyChecksum(void);
+uint8_t Bootloader_CheckForApplication(void);
+void    Bootloader_JumpToApplication(void);
+void    Bootloader_JumpToSysMem(void);
 
 uint32_t Bootloader_GetVersion(void);
 

--- a/projects/STM32L476-CustomHw/include/bsp_driver_sd.h
+++ b/projects/STM32L476-CustomHw/include/bsp_driver_sd.h
@@ -5,35 +5,44 @@
 #include "stm32l4xx_hal.h"
 
 /* Exported types ------------------------------------------------------------*/
-#define BSP_SD_CardInfo             HAL_SD_CardInfoTypeDef
+#define BSP_SD_CardInfo HAL_SD_CardInfoTypeDef
 
 /* Exported constants --------------------------------------------------------*/
-#define MSD_OK                      ((uint8_t)0x00)
-#define MSD_ERROR                   ((uint8_t)0x01)
-#define MSD_ERROR_SD_NOT_PRESENT    ((uint8_t)0x02)
+#define MSD_OK                   ((uint8_t)0x00)
+#define MSD_ERROR                ((uint8_t)0x01)
+#define MSD_ERROR_SD_NOT_PRESENT ((uint8_t)0x02)
 
-#define SD_TRANSFER_OK              ((uint8_t)0x00)
-#define SD_TRANSFER_BUSY            ((uint8_t)0x01)
-#define SD_TRANSFER_ERROR           ((uint8_t)0x02)
+#define SD_TRANSFER_OK    ((uint8_t)0x00)
+#define SD_TRANSFER_BUSY  ((uint8_t)0x01)
+#define SD_TRANSFER_ERROR ((uint8_t)0x02)
 
-#define SD_PRESENT                  ((uint8_t)0x01)
-#define SD_NOT_PRESENT              ((uint8_t)0x00)
+#define SD_PRESENT     ((uint8_t)0x01)
+#define SD_NOT_PRESENT ((uint8_t)0x00)
 
-#define SD_DATATIMEOUT              (150U)  /* ms */
+#define SD_DATATIMEOUT (150U) /* ms */
 
-#define SDMMC_IRQ_PRIO              1
-#define SD_DMA_IRQ_PRIO             2
+#define SDMMC_IRQ_PRIO  1
+#define SD_DMA_IRQ_PRIO 2
 
 /* Exported functions --------------------------------------------------------*/
 uint8_t BSP_SD_Init(void);
 uint8_t BSP_SD_DeInit(void);
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks);
-uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks);
+uint8_t BSP_SD_ReadBlocks(uint32_t* pData,
+                          uint32_t  ReadAddr,
+                          uint32_t  NumOfBlocks,
+                          uint32_t  Timeout);
+uint8_t BSP_SD_WriteBlocks(uint32_t* pData,
+                           uint32_t  WriteAddr,
+                           uint32_t  NumOfBlocks,
+                           uint32_t  Timeout);
+uint8_t
+        BSP_SD_ReadBlocks_DMA(uint32_t* pData, uint32_t ReadAddr, uint32_t NumOfBlocks);
+uint8_t BSP_SD_WriteBlocks_DMA(uint32_t* pData,
+                               uint32_t  WriteAddr,
+                               uint32_t  NumOfBlocks);
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr);
 uint8_t BSP_SD_GetCardState(void);
-void    BSP_SD_GetCardInfo(BSP_SD_CardInfo *CardInfo);
+void    BSP_SD_GetCardInfo(BSP_SD_CardInfo* CardInfo);
 uint8_t BSP_SD_IsDetected(void);
 
 __weak void BSP_SD_AbortCallback(void);

--- a/projects/STM32L476-CustomHw/include/fatfs.h
+++ b/projects/STM32L476-CustomHw/include/fatfs.h
@@ -2,7 +2,7 @@
 #define __fatfs_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/

--- a/projects/STM32L476-CustomHw/include/ffconf.h
+++ b/projects/STM32L476-CustomHw/include/ffconf.h
@@ -1,5 +1,5 @@
 #ifndef _FFCONF
-#define _FFCONF 68300	/* Revision ID */
+#define _FFCONF 68300 /* Revision ID */
 
 /*-----------------------------------------------------------------------------/
 / Additional user header to be used
@@ -11,13 +11,13 @@
 / Function Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _FS_READONLY        1      /* 0:Read/Write or 1:Read only */
+#define _FS_READONLY 1 /* 0:Read/Write or 1:Read only */
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
 /  and optional writing functions as well. */
 
-#define _FS_MINIMIZE        0      /* 0 to 3 */
+#define _FS_MINIMIZE 0 /* 0 to 3 */
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: All basic functions are enabled.
@@ -26,7 +26,7 @@
 /   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 /   3: f_lseek() function is removed in addition to 2. */
 
-#define _USE_STRFUNC        2      /* 0:Disable or 1-2:Enable */
+#define _USE_STRFUNC 2 /* 0:Disable or 1-2:Enable */
 /* This option switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -34,35 +34,37 @@
 /  1: Enable without LF-CRLF conversion.
 /  2: Enable with LF-CRLF conversion. */
 
-#define _USE_FIND           0
+#define _USE_FIND 0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
-#define _USE_MKFS           1
+#define _USE_MKFS 1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
-#define _USE_FASTSEEK       1
+#define _USE_FASTSEEK 1
 /* This option switches fast seek feature. (0:Disable or 1:Enable) */
 
-#define	_USE_EXPAND         0
+#define _USE_EXPAND 0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-#define _USE_CHMOD          0
-/* This option switches attribute manipulation functions, f_chmod() and f_utime().
-/  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this option. */
+#define _USE_CHMOD 0
+/* This option switches attribute manipulation functions, f_chmod() and
+f_utime().
+/  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this
+option. */
 
-#define _USE_LABEL          0
+#define _USE_LABEL 0
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 
-#define _USE_FORWARD        0
+#define _USE_FORWARD 0
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
 /*-----------------------------------------------------------------------------/
 / Locale and Namespace Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _CODE_PAGE          850
+#define _CODE_PAGE 850
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect setting of the code page can cause a file open failure.
 /
@@ -90,8 +92,8 @@
 /   950 - Traditional Chinese (DBCS)
 */
 
-#define _USE_LFN            1       /* 0 to 3 */
-#define _MAX_LFN            255     /* Maximum LFN length to handle (12 to 255) */
+#define _USE_LFN 1   /* 0 to 3 */
+#define _MAX_LFN 255 /* Maximum LFN length to handle (12 to 255) */
 /* The _USE_LFN switches the support of long file name (LFN).
 /
 /   0: Disable support of LFN. _MAX_LFN has no effect.
@@ -99,22 +101,23 @@
 /   2: Enable LFN with dynamic working buffer on the STACK.
 /   3: Enable LFN with dynamic working buffer on the HEAP.
 /
-/  To enable the LFN, Unicode handling functions (option/unicode.c) must be added
-/  to the project. The working buffer occupies (_MAX_LFN + 1) * 2 bytes and
-/  additional 608 bytes at exFAT enabled. _MAX_LFN can be in range from 12 to 255.
-/  It should be set 255 to support full featured LFN operations.
-/  When use stack for the working buffer, take care on stack overflow. When use heap
-/  memory for the working buffer, memory management functions, ff_memalloc() and
+/  To enable the LFN, Unicode handling functions (option/unicode.c) must be
+added /  to the project. The working buffer occupies (_MAX_LFN + 1) * 2 bytes
+and /  additional 608 bytes at exFAT enabled. _MAX_LFN can be in range from 12
+to 255. /  It should be set 255 to support full featured LFN operations. /  When
+use stack for the working buffer, take care on stack overflow. When use heap /
+memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree(), must be added to the project. */
 
-#define _LFN_UNICODE        0       /* 0:ANSI/OEM or 1:Unicode */
+#define _LFN_UNICODE 0 /* 0:ANSI/OEM or 1:Unicode */
 /* This option switches character encoding on the API. (0:ANSI/OEM or 1:UTF-16)
 /  To use Unicode string for the path name, enable LFN and set _LFN_UNICODE = 1.
 /  This option also affects behavior of string I/O functions. */
 
-#define _STRF_ENCODE        3
-/* When _LFN_UNICODE == 1, this option selects the character encoding ON THE FILE to
-/  be read/written via string I/O functions, f_gets(), f_putc(), f_puts and f_printf().
+#define _STRF_ENCODE 3
+/* When _LFN_UNICODE == 1, this option selects the character encoding ON THE
+FILE to /  be read/written via string I/O functions, f_gets(), f_putc(), f_puts
+and f_printf().
 /
 /  0: ANSI/OEM
 /  1: UTF-16LE
@@ -123,7 +126,7 @@
 /
 /  This option has no effect when _LFN_UNICODE == 0. */
 
-#define _FS_RPATH           0       /* 0 to 2 */
+#define _FS_RPATH 0 /* 0 to 2 */
 /* This option configures support of relative path.
 /
 /   0: Disable relative path and remove related functions.
@@ -135,41 +138,42 @@
 / Drive/Volume Configurations
 /----------------------------------------------------------------------------*/
 
-#define _VOLUMES            1
+#define _VOLUMES 1
 /* Number of volumes (logical drives) to be used. */
 
 /* USER CODE BEGIN Volumes */
-#define _STR_VOLUME_ID      0       /* 0:Use only 0-9 for drive ID, 1:Use strings for drive ID */
-#define _VOLUME_STRS        "RAM","NAND","CF","SD1","SD2","USB1","USB2","USB3"
+#define _STR_VOLUME_ID \
+    0 /* 0:Use only 0-9 for drive ID, 1:Use strings for drive ID */
+#define _VOLUME_STRS "RAM", "NAND", "CF", "SD1", "SD2", "USB1", "USB2", "USB3"
 /* _STR_VOLUME_ID switches string support of volume ID.
-/  When _STR_VOLUME_ID is set to 1, also pre-defined strings can be used as drive
-/  number in the path name. _VOLUME_STRS defines the drive ID strings for each
-/  logical drives. Number of items must be equal to _VOLUMES. Valid characters for
-/  the drive ID strings are: A-Z and 0-9. */
+/  When _STR_VOLUME_ID is set to 1, also pre-defined strings can be used as
+drive /  number in the path name. _VOLUME_STRS defines the drive ID strings for
+each /  logical drives. Number of items must be equal to _VOLUMES. Valid
+characters for /  the drive ID strings are: A-Z and 0-9. */
 /* USER CODE END Volumes */
 
-#define _MULTI_PARTITION    0       /* 0:Single partition, 1:Multiple partition */
+#define _MULTI_PARTITION 0 /* 0:Single partition, 1:Multiple partition */
 /* This option switches support of multi-partition on a physical drive.
 /  By default (0), each logical drive number is bound to the same physical drive
 /  number and only an FAT volume found on the physical drive will be mounted.
-/  When multi-partition is enabled (1), each logical drive number can be bound to
-/  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
-/  funciton will be available. */
-#define _MIN_SS             512     /* 512, 1024, 2048 or 4096 */
-#define _MAX_SS             512     /* 512, 1024, 2048 or 4096 */
+/  When multi-partition is enabled (1), each logical drive number can be bound
+to /  arbitrary physical drive and partition listed in the VolToPart[]. Also
+f_fdisk() /  funciton will be available. */
+#define _MIN_SS 512 /* 512, 1024, 2048 or 4096 */
+#define _MAX_SS 512 /* 512, 1024, 2048 or 4096 */
 /* These options configure the range of sector size to be supported. (512, 1024,
-/  2048 or 4096) Always set both 512 for most systems, all type of memory cards and
-/  harddisk. But a larger value may be required for on-board flash memory and some
-/  type of optical media. When _MAX_SS is larger than _MIN_SS, FatFs is configured
-/  to variable sector size and GET_SECTOR_SIZE command must be implemented to the
-/  disk_ioctl() function. */
+/  2048 or 4096) Always set both 512 for most systems, all type of memory cards
+and /  harddisk. But a larger value may be required for on-board flash memory
+and some /  type of optical media. When _MAX_SS is larger than _MIN_SS, FatFs is
+configured /  to variable sector size and GET_SECTOR_SIZE command must be
+implemented to the /  disk_ioctl() function. */
 
-#define	_USE_TRIM           0
+#define _USE_TRIM 0
 /* This option switches support of ATA-TRIM. (0:Disable or 1:Enable)
 /  To enable Trim function, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */
 
-#define _FS_NOFSINFO        0       /* 0,1,2 or 3 */
+#define _FS_NOFSINFO 0 /* 0,1,2 or 3 */
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.
@@ -184,44 +188,47 @@
 / System Configurations
 /----------------------------------------------------------------------------*/
 
-#define _FS_TINY            0       /* 0:Normal or 1:Tiny */
+#define _FS_TINY 0 /* 0:Normal or 1:Tiny */
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
-/  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS bytes.
-/  Instead of private sector buffer eliminated from the file object, common sector
-/  buffer in the file system object (FATFS) is used for the file data transfer. */
+/  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS
+bytes. /  Instead of private sector buffer eliminated from the file object,
+common sector /  buffer in the file system object (FATFS) is used for the file
+data transfer. */
 
-#define _FS_EXFAT	        0
+#define _FS_EXFAT 0
 /* This option switches support of exFAT file system. (0:Disable or 1:Enable)
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards C89 compatibility. */
 
-#define _FS_NORTC	        0
-#define _NORTC_MON	        6
-#define _NORTC_MDAY	        4
-#define _NORTC_YEAR	        2018
-/* The option _FS_NORTC switches timestamp functiton. If the system does not have
-/  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to disable
-/  the timestamp function. All objects modified by FatFs will have a fixed timestamp
-/  defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR in local time.
-/  To enable timestamp function (_FS_NORTC = 0), get_fattime() function need to be
-/  added to the project to get current time form real-time clock. _NORTC_MON,
-/  _NORTC_MDAY and _NORTC_YEAR have no effect.
-/  These options have no effect at read-only configuration (_FS_READONLY = 1). */
+#define _FS_NORTC   0
+#define _NORTC_MON  6
+#define _NORTC_MDAY 4
+#define _NORTC_YEAR 2018
+/* The option _FS_NORTC switches timestamp functiton. If the system does not
+have /  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to
+disable /  the timestamp function. All objects modified by FatFs will have a
+fixed timestamp /  defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR in local
+time. /  To enable timestamp function (_FS_NORTC = 0), get_fattime() function
+need to be /  added to the project to get current time form real-time clock.
+_NORTC_MON, /  _NORTC_MDAY and _NORTC_YEAR have no effect.
+/  These options have no effect at read-only configuration (_FS_READONLY = 1).
+*/
 
-#define _FS_LOCK            0       /* 0:Disable or >=1:Enable */
-/* The option _FS_LOCK switches file lock function to control duplicated file open
-/  and illegal operation to open objects. This option must be 0 when _FS_READONLY
-/  is 1.
+#define _FS_LOCK 0 /* 0:Disable or >=1:Enable */
+/* The option _FS_LOCK switches file lock function to control duplicated file
+open /  and illegal operation to open objects. This option must be 0 when
+_FS_READONLY /  is 1.
 /
-/  0:  Disable file lock function. To avoid volume corruption, application program
-/      should avoid illegal open, remove and rename to the open objects.
-/  >0: Enable file lock function. The value defines how many files/sub-directories
-/      can be opened simultaneously under file lock control. Note that the file
-/      lock control is independent of re-entrancy. */
+/  0:  Disable file lock function. To avoid volume corruption, application
+program /      should avoid illegal open, remove and rename to the open objects.
+/  >0: Enable file lock function. The value defines how many
+files/sub-directories /      can be opened simultaneously under file lock
+control. Note that the file /      lock control is independent of re-entrancy.
+*/
 
-#define _FS_REENTRANT       0       /* 0:Disable or 1:Enable */
-#define _FS_TIMEOUT         1000    /* Timeout period in unit of time ticks */
-#define _SYNC_t             osSemaphoreId
+#define _FS_REENTRANT 0    /* 0:Disable or 1:Enable */
+#define _FS_TIMEOUT   1000 /* Timeout period in unit of time ticks */
+#define _SYNC_t       osSemaphoreId
 /* The option _FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()
@@ -235,15 +242,15 @@
 /      option/syscall.c.
 /
 /  The _FS_TIMEOUT defines timeout period in unit of time tick.
-/  The _SYNC_t defines O/S dependent sync object type. e.g. HANDLE, ID, OS_EVENT*,
-/  SemaphoreHandle_t and etc.. A header file for O/S definitions needs to be
-/  included somewhere in the scope of ff.h. */
+/  The _SYNC_t defines O/S dependent sync object type. e.g. HANDLE, ID,
+OS_EVENT*, /  SemaphoreHandle_t and etc.. A header file for O/S definitions
+needs to be /  included somewhere in the scope of ff.h. */
 
 /* define the ff_malloc ff_free macros as standard malloc free */
 #if !defined(ff_malloc) && !defined(ff_free)
 #include <stdlib.h>
-#define ff_malloc  malloc
-#define ff_free  free
+#define ff_malloc malloc
+#define ff_free   free
 #endif
 
 #endif /* _FFCONF */

--- a/projects/STM32L476-CustomHw/include/main.h
+++ b/projects/STM32L476-CustomHw/include/main.h
@@ -2,44 +2,58 @@
 #define __MAIN_H
 
 /*** Application-Specific Configuration ***************************************/
-#define CONF_BUILD          "2018-04-18"    /* Bootloader build date [YYYY-MM-DD] */
-#define CONF_FILENAME       "GPP.bin"       /* File name of application located on SD card */
-
-#define USE_SWO_TRACE       1               /* For development/debugging: stdout/stderr via SWO trace */
+/* Bootloader build date [YYYY-MM-DD] */
+#define CONF_BUILD "2018-04-18"
+/* File name of application located on SD card */
+#define CONF_FILENAME "GPP.bin"
+/* For development/debugging: stdout/stderr via SWO trace */
+#define USE_SWO_TRACE 1
 /******************************************************************************/
 
 /* Hardware Defines ----------------------------------------------------------*/
-#define BTN_Port            GPIOB
-#define BTN_Pin             GPIO_PIN_8
+#define BTN_Port GPIOB
+#define BTN_Pin  GPIO_PIN_8
 
-#define LED_R_Port          GPIOB
-#define LED_R_Pin           GPIO_PIN_4
-#define LED_Y_Port          GPIOB
-#define LED_Y_Pin           GPIO_PIN_5
-#define LED_G_Port          GPIOB
-#define LED_G_Pin           GPIO_PIN_6
+#define LED_R_Port GPIOB
+#define LED_R_Pin  GPIO_PIN_4
+#define LED_Y_Port GPIOB
+#define LED_Y_Pin  GPIO_PIN_5
+#define LED_G_Port GPIOB
+#define LED_G_Pin  GPIO_PIN_6
 
-#define SD_PWR_Port         GPIOC
-#define SD_PWR_Pin          GPIO_PIN_7
+#define SD_PWR_Port GPIOC
+#define SD_PWR_Pin  GPIO_PIN_7
 
 /* Hardware Macros -----------------------------------------------------------*/
-#define SDCARD_ON()         HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_RESET)
-#define SDCARD_OFF()        HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_SET)
+#define SDCARD_ON()  HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_RESET)
+#define SDCARD_OFF() HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_SET)
 
-#define LED_G_ON()          HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_SET)
-#define LED_G_OFF()         HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_RESET)
-#define LED_G_TG()          HAL_GPIO_TogglePin(LED_G_Port, LED_G_Pin)
-#define LED_Y_ON()          HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_SET)
-#define LED_Y_OFF()         HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_RESET)
-#define LED_Y_TG()          HAL_GPIO_TogglePin(LED_Y_Port, LED_Y_Pin)
-#define LED_R_ON()          HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_SET)
-#define LED_R_OFF()         HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_RESET)
-#define LED_R_TG()          HAL_GPIO_TogglePin(LED_R_Port, LED_R_Pin)
+#define LED_G_ON()  HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_SET)
+#define LED_G_OFF() HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_RESET)
+#define LED_G_TG()  HAL_GPIO_TogglePin(LED_G_Port, LED_G_Pin)
+#define LED_Y_ON()  HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_SET)
+#define LED_Y_OFF() HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_RESET)
+#define LED_Y_TG()  HAL_GPIO_TogglePin(LED_Y_Port, LED_Y_Pin)
+#define LED_R_ON()  HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_SET)
+#define LED_R_OFF() HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_RESET)
+#define LED_R_TG()  HAL_GPIO_TogglePin(LED_R_Port, LED_R_Pin)
 
-#define LED_ALL_ON()        do { LED_G_ON(); LED_Y_ON(); LED_R_ON(); } while(0)
-#define LED_ALL_OFF()       do { LED_G_OFF(); LED_Y_OFF(); LED_R_OFF(); } while(0)
+#define LED_ALL_ON() \
+    do               \
+    {                \
+        LED_G_ON();  \
+        LED_Y_ON();  \
+        LED_R_ON();  \
+    } while(0)
+#define LED_ALL_OFF() \
+    do                \
+    {                 \
+        LED_G_OFF();  \
+        LED_Y_OFF();  \
+        LED_R_OFF();  \
+    } while(0)
 
-#define IS_BTN_PRESSED()    ((HAL_GPIO_ReadPin(BTN_Port, BTN_Pin) == GPIO_PIN_RESET) ? 1 : 0)
-
+#define IS_BTN_PRESSED() \
+    ((HAL_GPIO_ReadPin(BTN_Port, BTN_Pin) == GPIO_PIN_RESET) ? 1 : 0)
 
 #endif /* __MAIN_H */

--- a/projects/STM32L476-CustomHw/include/stm32l4xx_hal_conf.h
+++ b/projects/STM32L476-CustomHw/include/stm32l4xx_hal_conf.h
@@ -2,7 +2,7 @@
 #define __STM32L4xx_HAL_CONF_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #include "main.h"
@@ -10,7 +10,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 /* ######################### Custom Definitions ############################# */
-#define SDMMC_HAL_TIMEOUT   500     /* [ms] */
+#define SDMMC_HAL_TIMEOUT 500 /* [ms] */
 
 /* ########################## Module Selection ############################## */
 #define HAL_MODULE_ENABLED
@@ -62,107 +62,120 @@
 //#define HAL_USART_MODULE_ENABLED
 //#define HAL_WWDG_MODULE_ENABLED
 
-/* ########################## Oscillator Values adaptation ####################*/
+/* ######################### Oscillator Values adaptation ####################*/
 /**
-  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
-  *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSE is used as system clock source, directly or through the PLL).
-  */
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+ * @brief Adjust the value of External High Speed oscillator (HSE) used in your
+ * application. This value is used by the RCC HAL module to compute the system
+ * frequency (when HSE is used as system clock source, directly or through the
+ * PLL).
+ */
+#if !defined(HSE_VALUE)
+#define HSE_VALUE \
+    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
+#endif                   /* HSE_VALUE */
 
-#if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100U)   /*!< Time out for HSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
-
-/**
-  * @brief Internal Multiple Speed oscillator (MSI) default value.
-  *        This value is the default MSI range value after Reset.
-  */
-#if !defined  (MSI_VALUE)
-  #define MSI_VALUE    ((uint32_t)4000000U) /*!< Value of the Internal oscillator in Hz*/
-#endif /* MSI_VALUE */
-/**
-  * @brief Internal High Speed oscillator (HSI) value.
-  *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSI is used as system clock source, directly or through the PLL).
-  */
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
+#if !defined(HSE_STARTUP_TIMEOUT)
+#define HSE_STARTUP_TIMEOUT \
+    ((uint32_t)100U) /*!< Time out for HSE start up, in ms */
+#endif               /* HSE_STARTUP_TIMEOUT */
 
 /**
-  * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and RNG.
-  *        This internal oscillator is mainly dedicated to provide a high precision clock to
-  *        the USB peripheral by means of a special Clock Recovery System (CRS) circuitry.
-  *        When the CRS is not used, the HSI48 RC oscillator runs on it default frequency
-  *        which is subject to manufacturing process variations.
-  */
-#if !defined  (HSI48_VALUE)
- #define HSI48_VALUE   ((uint32_t)48000000U) /*!< Value of the Internal High Speed oscillator for USB FS/SDMMC/RNG in Hz.
-                                              The real value my vary depending on manufacturing process variations.*/
-#endif /* HSI48_VALUE */
+ * @brief Internal Multiple Speed oscillator (MSI) default value.
+ *        This value is the default MSI range value after Reset.
+ */
+#if !defined(MSI_VALUE)
+#define MSI_VALUE \
+    ((uint32_t)4000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif                   /* MSI_VALUE */
+/**
+ * @brief Internal High Speed oscillator (HSI) value.
+ *        This value is used by the RCC HAL module to compute the system
+ * frequency (when HSI is used as system clock source, directly or through the
+ * PLL).
+ */
+#if !defined(HSI_VALUE)
+#define HSI_VALUE \
+    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif                    /* HSI_VALUE */
 
 /**
-  * @brief Internal Low Speed oscillator (LSI) value.
-  */
-#if !defined  (LSI_VALUE)
- #define LSI_VALUE  ((uint32_t)32000U)       /*!< LSI Typical Value in Hz*/
-#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
-                                             The real value may vary depending on the variations
-                                             in voltage and temperature.*/
+ * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and
+ * RNG. This internal oscillator is mainly dedicated to provide a high precision
+ * clock to the USB peripheral by means of a special Clock Recovery System (CRS)
+ * circuitry. When the CRS is not used, the HSI48 RC oscillator runs on it
+ * default frequency which is subject to manufacturing process variations.
+ */
+#if !defined(HSI48_VALUE)
+#define HSI48_VALUE                                                            \
+    ((uint32_t)48000000U) /*!< Value of the Internal High Speed oscillator for \
+                           USB FS/SDMMC/RNG in Hz. The real value my vary      \
+                           depending on manufacturing process variations.*/
+#endif                    /* HSI48_VALUE */
 
 /**
-  * @brief External Low Speed oscillator (LSE) value.
-  *        This value is used by the UART, RTC HAL module to compute the system frequency
-  */
-#if !defined  (LSE_VALUE)
-  #define LSE_VALUE    ((uint32_t)32768U) /*!< Value of the External oscillator in Hz*/
-#endif /* LSE_VALUE */
-
-#if !defined  (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000U)   /*!< Time out for LSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
+ * @brief Internal Low Speed oscillator (LSI) value.
+ */
+#if !defined(LSI_VALUE)
+#define LSI_VALUE ((uint32_t)32000U) /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
+                        The real value may vary depending on the variations  \
+                        in voltage and temperature.*/
 
 /**
-  * @brief External clock source for SAI1 peripheral
-  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
-  *        frequency.
-  */
-#if !defined  (EXTERNAL_SAI1_CLOCK_VALUE)
-  #define EXTERNAL_SAI1_CLOCK_VALUE    ((uint32_t)2097000U) /*!< Value of the SAI1 External clock source in Hz*/
-#endif /* EXTERNAL_SAI1_CLOCK_VALUE */
+ * @brief External Low Speed oscillator (LSE) value.
+ *        This value is used by the UART, RTC HAL module to compute the system
+ * frequency
+ */
+#if !defined(LSE_VALUE)
+#define LSE_VALUE \
+    ((uint32_t)32768U) /*!< Value of the External oscillator in Hz*/
+#endif                 /* LSE_VALUE */
+
+#if !defined(LSE_STARTUP_TIMEOUT)
+#define LSE_STARTUP_TIMEOUT \
+    ((uint32_t)5000U) /*!< Time out for LSE start up, in ms */
+#endif                /* HSE_STARTUP_TIMEOUT */
 
 /**
-  * @brief External clock source for SAI2 peripheral
-  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
-  *        frequency.
-  */
-#if !defined  (EXTERNAL_SAI2_CLOCK_VALUE)
-  #define EXTERNAL_SAI2_CLOCK_VALUE    ((uint32_t)2097000U) /*!< Value of the SAI2 External clock source in Hz*/
-#endif /* EXTERNAL_SAI2_CLOCK_VALUE */
+ * @brief External clock source for SAI1 peripheral
+ *        This value is used by the RCC HAL module to compute the SAI1 & SAI2
+ * clock source frequency.
+ */
+#if !defined(EXTERNAL_SAI1_CLOCK_VALUE)
+#define EXTERNAL_SAI1_CLOCK_VALUE \
+    ((uint32_t)2097000U) /*!< Value of the SAI1 External clock source in Hz*/
+#endif                   /* EXTERNAL_SAI1_CLOCK_VALUE */
+
+/**
+ * @brief External clock source for SAI2 peripheral
+ *        This value is used by the RCC HAL module to compute the SAI1 & SAI2
+ * clock source frequency.
+ */
+#if !defined(EXTERNAL_SAI2_CLOCK_VALUE)
+#define EXTERNAL_SAI2_CLOCK_VALUE \
+    ((uint32_t)2097000U) /*!< Value of the SAI2 External clock source in Hz*/
+#endif                   /* EXTERNAL_SAI2_CLOCK_VALUE */
 
 /* Tip: To avoid modifying this file each time you need to use different HSE,
    ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
 /* ########################### System Configuration ######################### */
 /**
-  * @brief This is the HAL system configuration section
-  */
+ * @brief This is the HAL system configuration section
+ */
 
-#define  VDD_VALUE                  ((uint32_t)3000U) /*!< Value of VDD in mv */
-#define  TICK_INT_PRIORITY          ((uint32_t)0U)    /*!< tick interrupt priority */
-#define  USE_RTOS                   0U
-#define  PREFETCH_ENABLE            0U
-#define  INSTRUCTION_CACHE_ENABLE   1U
-#define  DATA_CACHE_ENABLE          1U
+#define VDD_VALUE                ((uint32_t)3000U) /*!< Value of VDD in mv */
+#define TICK_INT_PRIORITY        ((uint32_t)0U) /*!< tick interrupt priority */
+#define USE_RTOS                 0U
+#define PREFETCH_ENABLE          0U
+#define INSTRUCTION_CACHE_ENABLE 1U
+#define DATA_CACHE_ENABLE        1U
 
 /* ########################## Assert Selection ############################## */
 /**
-  * @brief Uncomment the line below to expanse the "assert_param" macro in the
-  *        HAL drivers code
-  */
+ * @brief Uncomment the line below to expanse the "assert_param" macro in the
+ *        HAL drivers code
+ */
 /* #define USE_FULL_ASSERT    1U */
 
 /* ################## SPI peripheral configuration ########################## */
@@ -172,214 +185,215 @@
  * Deactivated: CRC code cleaned from driver
  */
 
-#define USE_SPI_CRC                 0U
+#define USE_SPI_CRC 0U
 
 /* Includes ------------------------------------------------------------------*/
 /**
-  * @brief Include module's header file
-  */
+ * @brief Include module's header file
+ */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-  #include "stm32l4xx_hal_rcc.h"
-  #include "stm32l4xx_hal_rcc_ex.h"
+#include "stm32l4xx_hal_rcc.h"
+#include "stm32l4xx_hal_rcc_ex.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-  #include "stm32l4xx_hal_gpio.h"
+#include "stm32l4xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-  #include "stm32l4xx_hal_dma.h"
-  #include "stm32l4xx_hal_dma_ex.h"
+#include "stm32l4xx_hal_dma.h"
+#include "stm32l4xx_hal_dma_ex.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
 
 #ifdef HAL_DFSDM_MODULE_ENABLED
-  #include "stm32l4xx_hal_dfsdm.h"
+#include "stm32l4xx_hal_dfsdm.h"
 #endif /* HAL_DFSDM_MODULE_ENABLED */
 
 #ifdef HAL_CORTEX_MODULE_ENABLED
-  #include "stm32l4xx_hal_cortex.h"
+#include "stm32l4xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-  #include "stm32l4xx_hal_adc.h"
+#include "stm32l4xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_CAN_MODULE_ENABLED
-  #include "stm32l4xx_hal_can.h"
+#include "stm32l4xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-  #include "stm32l4xx_hal_comp.h"
+#include "stm32l4xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-  #include "stm32l4xx_hal_crc.h"
+#include "stm32l4xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_CRYP_MODULE_ENABLED
-  #include "stm32l4xx_hal_cryp.h"
+#include "stm32l4xx_hal_cryp.h"
 #endif /* HAL_CRYP_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-  #include "stm32l4xx_hal_dac.h"
+#include "stm32l4xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_DCMI_MODULE_ENABLED
-  #include "stm32l4xx_hal_dcmi.h"
+#include "stm32l4xx_hal_dcmi.h"
 #endif /* HAL_DCMI_MODULE_ENABLED */
 
 #ifdef HAL_DMA2D_MODULE_ENABLED
-  #include "stm32l4xx_hal_dma2d.h"
+#include "stm32l4xx_hal_dma2d.h"
 #endif /* HAL_DMA2D_MODULE_ENABLED */
 
 #ifdef HAL_DSI_MODULE_ENABLED
-  #include "stm32l4xx_hal_dsi.h"
+#include "stm32l4xx_hal_dsi.h"
 #endif /* HAL_DSI_MODULE_ENABLED */
 
 #ifdef HAL_FIREWALL_MODULE_ENABLED
-  #include "stm32l4xx_hal_firewall.h"
+#include "stm32l4xx_hal_firewall.h"
 #endif /* HAL_FIREWALL_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-  #include "stm32l4xx_hal_flash.h"
+#include "stm32l4xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_HASH_MODULE_ENABLED
-  #include "stm32l4xx_hal_hash.h"
+#include "stm32l4xx_hal_hash.h"
 #endif /* HAL_HASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-  #include "stm32l4xx_hal_sram.h"
+#include "stm32l4xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-  #include "stm32l4xx_hal_nor.h"
+#include "stm32l4xx_hal_nor.h"
 #endif /* HAL_NOR_MODULE_ENABLED */
 
 #ifdef HAL_NAND_MODULE_ENABLED
-  #include "stm32l4xx_hal_nand.h"
+#include "stm32l4xx_hal_nand.h"
 #endif /* HAL_NAND_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
-  #include "stm32l4xx_hal_i2c.h"
+#include "stm32l4xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-  #include "stm32l4xx_hal_iwdg.h"
+#include "stm32l4xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_LCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_lcd.h"
+#include "stm32l4xx_hal_lcd.h"
 #endif /* HAL_LCD_MODULE_ENABLED */
 
 #ifdef HAL_LPTIM_MODULE_ENABLED
-  #include "stm32l4xx_hal_lptim.h"
+#include "stm32l4xx_hal_lptim.h"
 #endif /* HAL_LPTIM_MODULE_ENABLED */
 
 #ifdef HAL_LTDC_MODULE_ENABLED
-  #include "stm32l4xx_hal_ltdc.h"
+#include "stm32l4xx_hal_ltdc.h"
 #endif /* HAL_LTDC_MODULE_ENABLED */
 
 #ifdef HAL_OPAMP_MODULE_ENABLED
-  #include "stm32l4xx_hal_opamp.h"
+#include "stm32l4xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_OSPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_ospi.h"
+#include "stm32l4xx_hal_ospi.h"
 #endif /* HAL_OSPI_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-  #include "stm32l4xx_hal_pwr.h"
+#include "stm32l4xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_QSPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_qspi.h"
+#include "stm32l4xx_hal_qspi.h"
 #endif /* HAL_QSPI_MODULE_ENABLED */
 
 #ifdef HAL_RNG_MODULE_ENABLED
-  #include "stm32l4xx_hal_rng.h"
+#include "stm32l4xx_hal_rng.h"
 #endif /* HAL_RNG_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-  #include "stm32l4xx_hal_rtc.h"
+#include "stm32l4xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SAI_MODULE_ENABLED
-  #include "stm32l4xx_hal_sai.h"
+#include "stm32l4xx_hal_sai.h"
 #endif /* HAL_SAI_MODULE_ENABLED */
 
 #ifdef HAL_SD_MODULE_ENABLED
-  #include "stm32l4xx_hal_sd.h"
+#include "stm32l4xx_hal_sd.h"
 #endif /* HAL_SD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
-  #include "stm32l4xx_hal_smbus.h"
+#include "stm32l4xx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_spi.h"
+#include "stm32l4xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_SWPMI_MODULE_ENABLED
-  #include "stm32l4xx_hal_swpmi.h"
+#include "stm32l4xx_hal_swpmi.h"
 #endif /* HAL_SWPMI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-  #include "stm32l4xx_hal_tim.h"
+#include "stm32l4xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-  #include "stm32l4xx_hal_tsc.h"
+#include "stm32l4xx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-  #include "stm32l4xx_hal_uart.h"
+#include "stm32l4xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-  #include "stm32l4xx_hal_usart.h"
+#include "stm32l4xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-  #include "stm32l4xx_hal_irda.h"
+#include "stm32l4xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-  #include "stm32l4xx_hal_smartcard.h"
+#include "stm32l4xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-  #include "stm32l4xx_hal_wwdg.h"
+#include "stm32l4xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_pcd.h"
+#include "stm32l4xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_HCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_hcd.h"
+#include "stm32l4xx_hal_hcd.h"
 #endif /* HAL_HCD_MODULE_ENABLED */
 
 #ifdef HAL_GFXMMU_MODULE_ENABLED
-  #include "stm32l4xx_hal_gfxmmu.h"
+#include "stm32l4xx_hal_gfxmmu.h"
 #endif /* HAL_GFXMMU_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 /**
-  * @brief  The assert_param macro is used for function's parameters check.
-  * @param  expr: If expr is false, it calls assert_failed function
-  *         which reports the name of the source file and the source
-  *         line number of the call that failed.
-  *         If expr is true, it returns no value.
-  * @retval None
-  */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+ * @brief  The assert_param macro is used for function's parameters check.
+ * @param  expr: If expr is false, it calls assert_failed function
+ *         which reports the name of the source file and the source
+ *         line number of the call that failed.
+ *         If expr is true, it returns no value.
+ * @retval None
+ */
+#define assert_param(expr) \
+    ((expr) ? (void)0U : assert_failed((uint8_t*)__FILE__, __LINE__))
 /* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+void assert_failed(uint8_t* file, uint32_t line);
 #else
-  #define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */
 
 #ifdef __cplusplus

--- a/projects/STM32L476-CustomHw/include/stm32l4xx_it.h
+++ b/projects/STM32L476-CustomHw/include/stm32l4xx_it.h
@@ -2,7 +2,7 @@
 #define __STM32L4xx_IT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/

--- a/projects/STM32L476-CustomHw/source/bsp_driver_sd.c
+++ b/projects/STM32L476-CustomHw/source/bsp_driver_sd.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   bsp_driver_sd.c
-  * @brief  SD BSP driver
-  *	        This file contains the implementation of the SD BSP driver used by
-  *         the FatFs module. The driver uses the HAL library of ST.
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   bsp_driver_sd.c
+ * @brief  SD BSP driver
+ *	       This file contains the implementation of the SD BSP driver used by
+ *         the FatFs module. The driver uses the HAL library of ST.
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "bsp_driver_sd.h"
 
@@ -19,38 +19,38 @@
 SD_HandleTypeDef hsd1;
 
 /* Private function prototypes -----------------------------------------------*/
-static void BSP_SD_MspInit(void);
-static void BSP_SD_MspDeInit(void);
-static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd);
-static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef *hsd);
+static void              BSP_SD_MspInit(void);
+static void              BSP_SD_MspDeInit(void);
+static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef* hsd);
+static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef* hsd);
 
 /* External function prototypes ----------------------------------------------*/
 void Error_Handler(void);
 
 /**
-  * @brief  Initializes the SD card device.
-  * @retval SD status
-  */
+ * @brief  Initializes the SD card device.
+ * @retval SD status
+ */
 uint8_t BSP_SD_Init(void)
 {
     uint8_t tries;
 
     /* Check if the SD card is plugged in the slot */
-    if (BSP_SD_IsDetected() != SD_PRESENT)
+    if(BSP_SD_IsDetected() != SD_PRESENT)
     {
         return MSD_ERROR_SD_NOT_PRESENT;
     }
 
     /* SD interface configuration */
-    hsd1.Instance = SDMMC1;
-    hsd1.Init.ClockEdge = SDMMC_CLOCK_EDGE_RISING;
-    hsd1.Init.ClockBypass = SDMMC_CLOCK_BYPASS_DISABLE;
-    hsd1.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE;
-    hsd1.Init.BusWide = SDMMC_BUS_WIDE_1B;
+    hsd1.Instance                 = SDMMC1;
+    hsd1.Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
+    hsd1.Init.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
+    hsd1.Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
+    hsd1.Init.BusWide             = SDMMC_BUS_WIDE_1B;
     hsd1.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_ENABLE;
-    hsd1.Init.ClockDiv = 0;
+    hsd1.Init.ClockDiv            = 0;
 
-    for(tries=0; tries<5; ++tries)
+    for(tries = 0; tries < 5; ++tries)
     {
         /* Msp SD initialization */
         BSP_SD_MspDeInit();
@@ -77,9 +77,9 @@ uint8_t BSP_SD_Init(void)
 }
 
 /**
-  * @brief  De-Initializes the SD card device
-  * @retval None
-  */
+ * @brief  De-Initializes the SD card device
+ * @retval None
+ */
 uint8_t BSP_SD_DeInit(void)
 {
     /* HAL SD de-initialization */
@@ -93,42 +93,47 @@ uint8_t BSP_SD_DeInit(void)
     __HAL_RCC_SDMMC1_RELEASE_RESET();
 
     /* Misc */
-    hsd1.State = HAL_SD_STATE_RESET;
-    hsd1.Context = 0;
-    hsd1.ErrorCode = 0;
-    hsd1.SdCard.CardType = 0;
-    hsd1.SdCard.CardVersion = 0;
-    hsd1.SdCard.Class = 0;
-    hsd1.SdCard.RelCardAdd = 0;
-    hsd1.SdCard.BlockNbr = 0;
-    hsd1.SdCard.BlockSize = 0;
-    hsd1.SdCard.LogBlockNbr = 0;
+    hsd1.State               = HAL_SD_STATE_RESET;
+    hsd1.Context             = 0;
+    hsd1.ErrorCode           = 0;
+    hsd1.SdCard.CardType     = 0;
+    hsd1.SdCard.CardVersion  = 0;
+    hsd1.SdCard.Class        = 0;
+    hsd1.SdCard.RelCardAdd   = 0;
+    hsd1.SdCard.BlockNbr     = 0;
+    hsd1.SdCard.BlockSize    = 0;
+    hsd1.SdCard.LogBlockNbr  = 0;
     hsd1.SdCard.LogBlockSize = 0;
-    hsd1.CSD[0] = 0;
-    hsd1.CSD[1] = 0;
-    hsd1.CSD[2] = 0;
-    hsd1.CSD[3] = 0;
-    hsd1.CID[0] = 0;
-    hsd1.CID[1] = 0;
-    hsd1.CID[2] = 0;
-    hsd1.CID[3] = 0;
+    hsd1.CSD[0]              = 0;
+    hsd1.CSD[1]              = 0;
+    hsd1.CSD[2]              = 0;
+    hsd1.CSD[3]              = 0;
+    hsd1.CID[0]              = 0;
+    hsd1.CID[1]              = 0;
+    hsd1.CID[2]              = 0;
+    hsd1.CID[3]              = 0;
 
-    return  MSD_OK;
+    return MSD_OK;
 }
 
 /**
-  * @brief  Reads block(s) from a specified address in an SD card, in polling mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  ReadAddr: Address from where data is to be read
-  * @param  NumOfBlocks: Number of SD blocks to read
-  * @param  Timeout: Timeout for read operation
-  * @retval SD status
-  */
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout)
+ * @brief  Reads block(s) from a specified address in an SD card, in polling
+ * mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  ReadAddr: Address from where data is to be read
+ * @param  NumOfBlocks: Number of SD blocks to read
+ * @param  Timeout: Timeout for read operation
+ * @retval SD status
+ */
+uint8_t BSP_SD_ReadBlocks(uint32_t* pData,
+                          uint32_t  ReadAddr,
+                          uint32_t  NumOfBlocks,
+                          uint32_t  Timeout)
 {
     uint8_t sd_state = MSD_OK;
 
-    if(HAL_SD_ReadBlocks(&hsd1, (uint8_t *)pData, ReadAddr, NumOfBlocks, Timeout) != HAL_OK)
+    if(HAL_SD_ReadBlocks(&hsd1, (uint8_t*)pData, ReadAddr, NumOfBlocks,
+                         Timeout) != HAL_OK)
     {
         sd_state = MSD_ERROR;
     }
@@ -137,18 +142,23 @@ uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBloc
 }
 
 /**
-  * @brief  Writes block(s) to a specified address in an SD card, in polling mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
-  * @param  NumOfBlocks: Number of SD blocks to write
-  * @param  Timeout: Timeout for write operation
-  * @retval SD status
-  */
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout)
+ * @brief  Writes block(s) to a specified address in an SD card, in polling
+ * mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  WriteAddr: Address from where data is to be written
+ * @param  NumOfBlocks: Number of SD blocks to write
+ * @param  Timeout: Timeout for write operation
+ * @retval SD status
+ */
+uint8_t BSP_SD_WriteBlocks(uint32_t* pData,
+                           uint32_t  WriteAddr,
+                           uint32_t  NumOfBlocks,
+                           uint32_t  Timeout)
 {
     uint8_t sd_state = MSD_OK;
 
-    if(HAL_SD_WriteBlocks(&hsd1, (uint8_t *)pData, WriteAddr, NumOfBlocks, Timeout) != HAL_OK)
+    if(HAL_SD_WriteBlocks(&hsd1, (uint8_t*)pData, WriteAddr, NumOfBlocks,
+                          Timeout) != HAL_OK)
     {
         sd_state = MSD_ERROR;
     }
@@ -157,13 +167,14 @@ uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBl
 }
 
 /**
-  * @brief  Reads block(s) from a specified address in an SD card, in DMA mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  ReadAddr: Address from where data is to be read
-  * @param  NumOfBlocks: Number of SD blocks to read
-  * @retval SD status
-  */
-uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks)
+ * @brief  Reads block(s) from a specified address in an SD card, in DMA mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  ReadAddr: Address from where data is to be read
+ * @param  NumOfBlocks: Number of SD blocks to read
+ * @retval SD status
+ */
+uint8_t
+BSP_SD_ReadBlocks_DMA(uint32_t* pData, uint32_t ReadAddr, uint32_t NumOfBlocks)
 {
     HAL_StatusTypeDef sd_state = HAL_OK;
 
@@ -176,20 +187,23 @@ uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOf
     if(sd_state == HAL_OK)
     {
         /* Read block(s) in DMA transfer mode */
-        sd_state = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t *)pData, ReadAddr, NumOfBlocks);
+        sd_state = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t*)pData, ReadAddr,
+                                         NumOfBlocks);
     }
 
     return (sd_state == HAL_OK) ? MSD_OK : MSD_ERROR;
 }
 
 /**
-  * @brief  Writes block(s) to a specified address in an SD card, in DMA mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
-  * @param  NumOfBlocks: Number of SD blocks to write
-  * @retval SD status
-  */
-uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks)
+ * @brief  Writes block(s) to a specified address in an SD card, in DMA mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  WriteAddr: Address from where data is to be written
+ * @param  NumOfBlocks: Number of SD blocks to write
+ * @retval SD status
+ */
+uint8_t BSP_SD_WriteBlocks_DMA(uint32_t* pData,
+                               uint32_t  WriteAddr,
+                               uint32_t  NumOfBlocks)
 {
     HAL_StatusTypeDef sd_state = HAL_OK;
 
@@ -199,21 +213,22 @@ uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t Num
     /* Prepare the dma channel for a read operation */
     sd_state = SD_DMAConfigTx(&hsd1);
 
-    if (sd_state == HAL_OK)
+    if(sd_state == HAL_OK)
     {
         /* Write block(s) in DMA transfer mode */
-        sd_state = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t *)pData, WriteAddr, NumOfBlocks);
+        sd_state = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t*)pData, WriteAddr,
+                                          NumOfBlocks);
     }
 
     return (sd_state == HAL_OK) ? MSD_OK : MSD_ERROR;
 }
 
 /**
-  * @brief  Erases the specified memory area of the given SD card.
-  * @param  StartAddr: Start byte address
-  * @param  EndAddr: End byte address
-  * @retval SD status
-  */
+ * @brief  Erases the specified memory area of the given SD card.
+ * @param  StartAddr: Start byte address
+ * @param  EndAddr: End byte address
+ * @retval SD status
+ */
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr)
 {
     uint8_t sd_state = MSD_OK;
@@ -227,13 +242,12 @@ uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr)
 }
 
 /**
-  * @brief  Gets the current SD card data status.
-  * @param  None
-  * @retval Data transfer state.
-  *          This value can be one of the following values:
-  *            @arg  SD_TRANSFER_OK: No data transfer is acting
-  *            @arg  SD_TRANSFER_BUSY: Data transfer is acting
-  */
+ * @brief  Gets the current SD card data status.
+ * @param  None
+ * @retval Data transfer state. This value can be one of the following values:
+ *         @arg  SD_TRANSFER_OK: No data transfer is acting
+ *         @arg  SD_TRANSFER_BUSY: Data transfer is acting
+ */
 uint8_t BSP_SD_GetCardState(void)
 {
     HAL_SD_CardStateTypedef card_state;
@@ -256,11 +270,11 @@ uint8_t BSP_SD_GetCardState(void)
 }
 
 /**
-  * @brief  Get SD information about specific SD card.
-  * @param  CardInfo: Pointer to HAL_SD_CardInfoTypedef structure
-  * @retval None
-  */
-void BSP_SD_GetCardInfo(BSP_SD_CardInfo *CardInfo)
+ * @brief  Get SD information about specific SD card.
+ * @param  CardInfo: Pointer to HAL_SD_CardInfoTypedef structure
+ * @retval None
+ */
+void BSP_SD_GetCardInfo(BSP_SD_CardInfo* CardInfo)
 {
     HAL_SD_GetCardInfo(&hsd1, CardInfo);
 }
@@ -275,90 +289,87 @@ uint8_t BSP_SD_IsDetected(void)
     return SD_PRESENT;
 }
 
-
 /**
-  * @brief SD Abort callbacks
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_AbortCallback(SD_HandleTypeDef *hsd)
+ * @brief SD Abort callbacks
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_AbortCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_AbortCallback();
 }
 
 /**
-  * @brief SD Error callbacks
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_ErrorCallback(SD_HandleTypeDef *hsd)
+ * @brief SD Error callbacks
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_ErrorCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_ErrorCallback();
 }
 
 /**
-  * @brief Rx Transfer completed callback
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_RxCpltCallback(SD_HandleTypeDef *hsd)
+ * @brief Rx Transfer completed callback
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_RxCpltCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_ReadCpltCallback();
 }
 
 /**
-  * @brief Tx Transfer completed callback
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_TxCpltCallback(SD_HandleTypeDef *hsd)
+ * @brief Tx Transfer completed callback
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_TxCpltCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_WriteCpltCallback();
 }
 
-
 /**
-  * @brief BSP SD Abort callback
-  * @retval None
-  */
+ * @brief BSP SD Abort callback
+ * @retval None
+ */
 __weak void BSP_SD_AbortCallback(void)
 {
     Error_Handler();
 }
 
 /**
-  * @brief BSP SD Error callback
-  * @retval None
-  */
+ * @brief BSP SD Error callback
+ * @retval None
+ */
 __weak void BSP_SD_ErrorCallback(void)
 {
     Error_Handler();
 }
 
 /**
-  * @brief BSP Rx Transfer completed callback
-  * @retval None
-  */
+ * @brief BSP Rx Transfer completed callback
+ * @retval None
+ */
 __weak void BSP_SD_ReadCpltCallback(void)
 {
     // redefined in sd_diskio
 }
 
 /**
-  * @brief BSP Tx Transfer completed callback
-  * @retval None
-  */
+ * @brief BSP Tx Transfer completed callback
+ * @retval None
+ */
 __weak void BSP_SD_WriteCpltCallback(void)
 {
     // redefined in sd_diskio
 }
 
-
 /**
-  * @brief Initializes the SD MSP.
-  * @param None
-  * @retval None
-  */
+ * @brief Initializes the SD MSP.
+ * @param None
+ * @retval None
+ */
 void BSP_SD_MspInit(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -380,7 +391,8 @@ void BSP_SD_MspInit(void)
     GPIO_InitStruct.Alternate = GPIO_AF12_SDMMC1;
 
     /* GPIOC configuration */
-    GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+    GPIO_InitStruct.Pin =
+        GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     /* GPIOD configuration */
@@ -394,14 +406,14 @@ void BSP_SD_MspInit(void)
     /* DMA initialization should be done here but
      * (as there is only one channel for RX and TX)
      * it is configured and done directly when required.
-    */
+     */
 }
 
 /**
-  * @brief De-Initializes the SD MSP.
-  * @param None
-  * @retval None
-  */
+ * @brief De-Initializes the SD MSP.
+ * @param None
+ * @retval None
+ */
 void BSP_SD_MspDeInit(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -422,7 +434,8 @@ void BSP_SD_MspDeInit(void)
     GPIO_InitStruct.Alternate = 0;
 
     /* GPIOC configuration */
-    GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+    GPIO_InitStruct.Pin =
+        GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     /* GPIOD configuration */
@@ -434,14 +447,14 @@ void BSP_SD_MspDeInit(void)
 }
 
 /**
-  * @brief Configure the DMA to receive data from the SD card
-  * @retval
-  *  HAL_ERROR or HAL_OK
-  */
-static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd)
+ * @brief Configure the DMA to receive data from the SD card
+ * @retval
+ *  HAL_ERROR or HAL_OK
+ */
+static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef* hsd)
 {
     static DMA_HandleTypeDef hdma_rx;
-    HAL_StatusTypeDef status = HAL_ERROR;
+    HAL_StatusTypeDef        status = HAL_ERROR;
 
     /* Configure DMA Rx parameters */
     hdma_rx.Instance                 = DMA2_Channel5;
@@ -473,14 +486,14 @@ static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd)
 }
 
 /**
-  * @brief Configure the DMA to transmit data to the SD card
-  * @retval
-  *  HAL_ERROR or HAL_OK
-  */
-static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef *hsd)
+ * @brief Configure the DMA to transmit data to the SD card
+ * @retval
+ *  HAL_ERROR or HAL_OK
+ */
+static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef* hsd)
 {
     static DMA_HandleTypeDef hdma_tx;
-    HAL_StatusTypeDef status;
+    HAL_StatusTypeDef        status;
 
     /* Configure DMA Tx parameters */
     hdma_tx.Instance                 = DMA2_Channel5;

--- a/projects/STM32L476-CustomHw/source/fatfs.c
+++ b/projects/STM32L476-CustomHw/source/fatfs.c
@@ -1,25 +1,25 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   fatfs.c
-  * @brief  FatFS application
-  *         Code for FatFS application
-  *
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   fatfs.c
+ * @brief  FatFS application
+ *         Code for FatFS application
+ *
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "fatfs.h"
 #include "main.h"
 
 /* Variables -----------------------------------------------------------------*/
-char  SDPath[4];        /* SD logical drive path */
-FATFS SDFatFs;          /* File system object for SD logical drive */
-FIL   SDFile;           /* File object for SD */
+char  SDPath[4]; /* SD logical drive path */
+FATFS SDFatFs;   /* File system object for SD logical drive */
+FIL   SDFile;    /* File object for SD */
 
 /* Functions -----------------------------------------------------------------*/
 uint8_t FATFS_Init(void)
@@ -33,10 +33,10 @@ uint8_t FATFS_DeInit(void)
 }
 
 /**
-  * @brief  Gets Time from RTC
-  * @param  None
-  * @retval Time in DWORD
-  */
+ * @brief  Gets Time from RTC
+ * @param  None
+ * @retval Time in DWORD
+ */
 DWORD get_fattime(void)
 {
     return (DWORD)0;

--- a/projects/STM32L476-CustomHw/source/main.c
+++ b/projects/STM32L476-CustomHw/source/main.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   main.c
-  * @brief  Main program
-  *	        This file demonstrates the usage of the bootloader.
-  *
-  * @see    Please refer to README for detailed information.
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   main.c
+ * @brief  Main program
+ *	       This file demonstrates the usage of the bootloader.
+ *
+ * @see    Please refer to README for detailed information.
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "stm32l4xx.h"
 #include "main.h"
@@ -22,9 +22,9 @@
 static uint8_t BTNcounter = 0;
 
 /* External variables --------------------------------------------------------*/
-extern char  SDPath[4];         /* SD logical drive path */
-extern FATFS SDFatFs;           /* File system object for SD logical drive */
-extern FIL   SDFile;            /* File object for SD */
+extern char  SDPath[4]; /* SD logical drive path */
+extern FATFS SDFatFs;   /* File system object for SD logical drive */
+extern FIL   SDFile;    /* File object for SD */
 
 /* Function prototypes -------------------------------------------------------*/
 void    Enter_Bootloader(void);
@@ -53,7 +53,7 @@ int main(void)
     if(__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST))
     {
         print("OBL flag is active.");
-#if (CLEAR_RESET_FLAGS)
+#if(CLEAR_RESET_FLAGS)
         /* Clear system reset flags */
         __HAL_RCC_CLEAR_RESET_FLAGS();
         print("Reset flags cleared.");
@@ -61,20 +61,44 @@ int main(void)
     }
 
     /* Check for user action:
-        - button is pressed >= 1 second:  Enter Bootloader. Green LED is blinking.
-        - button is pressed >= 4 seconds: Enter ST System Memory. Yellow LED is blinking.
+        - button is pressed >= 1 second:  Enter Bootloader. Green LED is
+          blinking.
+        - button is pressed >= 4 seconds: Enter ST System Memory. Yellow LED is
+          blinking.
         - button is pressed >= 9 seconds: Do nothing, launch application.
     */
     while(IS_BTN_PRESSED() && BTNcounter < 90)
     {
-        if(BTNcounter == 10) { print("Release button to enter Bootloader."); }
-        if(BTNcounter == 40) { print("Release button to enter System Memory."); }
+        if(BTNcounter == 10)
+        {
+            print("Release button to enter Bootloader.");
+        }
+        if(BTNcounter == 40)
+        {
+            print("Release button to enter System Memory.");
+        }
 
-        if(BTNcounter < 10)         { LED_ALL_ON(); }
-        else if(BTNcounter == 10)   { LED_ALL_OFF(); }
-        else if(BTNcounter < 40)    { LED_G_TG(); }
-        else if(BTNcounter == 40)   { LED_G_OFF(); LED_Y_ON(); }
-        else                        { LED_Y_TG(); }
+        if(BTNcounter < 10)
+        {
+            LED_ALL_ON();
+        }
+        else if(BTNcounter == 10)
+        {
+            LED_ALL_OFF();
+        }
+        else if(BTNcounter < 40)
+        {
+            LED_G_TG();
+        }
+        else if(BTNcounter == 40)
+        {
+            LED_G_OFF();
+            LED_Y_ON();
+        }
+        else
+        {
+            LED_Y_TG();
+        }
 
         BTNcounter++;
         HAL_Delay(100);
@@ -98,11 +122,10 @@ int main(void)
         }
     }
 
-
     /* Check if there is application in user flash area */
     if(Bootloader_CheckForApplication() == BL_OK)
     {
-#if (USE_CHECKSUM)
+#if(USE_CHECKSUM)
         /* Verify application checksum */
         if(Bootloader_VerifyChecksum() != BL_OK)
         {
@@ -132,10 +155,14 @@ int main(void)
     print("No application in flash.");
     while(1)
     {
-        LED_R_ON();     HAL_Delay(150);
-        LED_R_OFF();    HAL_Delay(150);
-        LED_R_ON();     HAL_Delay(150);
-        LED_R_OFF();    HAL_Delay(1050);
+        LED_R_ON();
+        HAL_Delay(150);
+        LED_R_OFF();
+        HAL_Delay(150);
+        LED_R_ON();
+        HAL_Delay(150);
+        LED_R_OFF();
+        HAL_Delay(1050);
     }
 }
 
@@ -157,13 +184,14 @@ void Enter_Bootloader(void)
         print("Application space in flash is write protected.");
         print("Press button to disable flash write protection...");
         LED_R_ON();
-        for(i=0; i<100; ++i)
+        for(i = 0; i < 100; ++i)
         {
             LED_Y_TG();
             HAL_Delay(50);
             if(IS_BTN_PRESSED())
             {
-                print("Disabling write protection and generating system reset...");
+                print("Disabling write protection and generating system "
+                      "reset...");
                 Bootloader_ConfigProtection(BL_PROTECTION_NONE);
             }
         }
@@ -210,7 +238,7 @@ void Enter_Bootloader(void)
     print("Software found on SD.");
 
     /* Check size of application found on SD card */
-    if(Bootloader_CheckSize( f_size(&SDFile) ) != BL_OK)
+    if(Bootloader_CheckSize(f_size(&SDFile)) != BL_OK)
     {
         print("Error: app on SD card is too large.");
 
@@ -250,7 +278,7 @@ void Enter_Bootloader(void)
     do
     {
         data = 0xFFFFFFFFFFFFFFFF;
-        fr = f_read(&SDFile, &data, 8, &num);
+        fr   = f_read(&SDFile, &data, 8, &num);
         if(num)
         {
             status = Bootloader_FlashNext(data);
@@ -260,7 +288,7 @@ void Enter_Bootloader(void)
             }
             else
             {
-                sprintf(msg, "Programming error at: %lu byte", (cntr*8));
+                sprintf(msg, "Programming error at: %lu byte", (cntr * 8));
                 print(msg);
 
                 f_close(&SDFile);
@@ -285,7 +313,7 @@ void Enter_Bootloader(void)
     LED_G_OFF();
     LED_Y_OFF();
     print("Programming finished.");
-    sprintf(msg, "Flashed: %lu bytes.", (cntr*8));
+    sprintf(msg, "Flashed: %lu bytes.", (cntr * 8));
     print(msg);
 
     /* Open file for verification */
@@ -308,7 +336,7 @@ void Enter_Bootloader(void)
     do
     {
         data = 0xFFFFFFFFFFFFFFFF;
-        fr = f_read(&SDFile, &data, 4, &num);
+        fr   = f_read(&SDFile, &data, 4, &num);
         if(num)
         {
             if(*(uint32_t*)addr == (uint32_t)data)
@@ -318,7 +346,7 @@ void Enter_Bootloader(void)
             }
             else
             {
-                sprintf(msg, "Verification error at: %lu byte.", (cntr*4));
+                sprintf(msg, "Verification error at: %lu byte.", (cntr * 4));
                 print(msg);
 
                 f_close(&SDFile);
@@ -343,7 +371,7 @@ void Enter_Bootloader(void)
     print("SD ejected.");
 
     /* Enable flash write protection */
-#if (USE_WRITE_PROTECTION)
+#if(USE_WRITE_PROTECTION)
     print("Enablig flash write protection and generating system reset...");
     if(Bootloader_ConfigProtection(BL_PROTECTION_WRP) != BL_OK)
     {
@@ -400,8 +428,8 @@ void GPIO_Init(void)
     HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_SET);
 
     /* LED_G_Pin, LED_Y_Pin, LED_R_Pin */
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull  = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 
     GPIO_InitStruct.Pin = LED_G_Pin;
@@ -414,16 +442,16 @@ void GPIO_Init(void)
     HAL_GPIO_Init(LED_R_Port, &GPIO_InitStruct);
 
     /* SD Card Power Pin */
-    GPIO_InitStruct.Pin = SD_PWR_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Pin   = SD_PWR_Pin;
+    GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull  = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(SD_PWR_Port, &GPIO_InitStruct);
 
     /* User Button */
-    GPIO_InitStruct.Pin = BTN_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    GPIO_InitStruct.Pin   = BTN_Pin;
+    GPIO_InitStruct.Mode  = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull  = GPIO_PULLUP;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(BTN_Port, &GPIO_InitStruct);
 }
@@ -442,30 +470,31 @@ void GPIO_DeInit(void)
 /*** System Clock Configuration ***/
 void SystemClock_Config(void)
 {
-    RCC_OscInitTypeDef RCC_OscInitStruct;
-    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+    RCC_OscInitTypeDef       RCC_OscInitStruct;
+    RCC_ClkInitTypeDef       RCC_ClkInitStruct;
     RCC_PeriphCLKInitTypeDef PeriphClkInit;
 
     /* Initializes the CPU, AHB and APB bus clocks */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
-    RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+    RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI;
+    RCC_OscInitStruct.MSIState            = RCC_MSI_ON;
     RCC_OscInitStruct.MSICalibrationValue = 0;
-    RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
-    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
-    RCC_OscInitStruct.PLL.PLLM = 1;
-    RCC_OscInitStruct.PLL.PLLN = 24;
-    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV7;
-    RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
-    RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+    RCC_OscInitStruct.MSIClockRange       = RCC_MSIRANGE_6;
+    RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_MSI;
+    RCC_OscInitStruct.PLL.PLLM            = 1;
+    RCC_OscInitStruct.PLL.PLLN            = 24;
+    RCC_OscInitStruct.PLL.PLLP            = RCC_PLLP_DIV7;
+    RCC_OscInitStruct.PLL.PLLQ            = RCC_PLLQ_DIV2;
+    RCC_OscInitStruct.PLL.PLLR            = RCC_PLLR_DIV2;
     if(HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
     {
         Error_Handler();
     }
 
-    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
-    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                                  RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
@@ -474,14 +503,14 @@ void SystemClock_Config(void)
         Error_Handler();
     }
 
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_SDMMC1;
-    PeriphClkInit.Sdmmc1ClockSelection = RCC_SDMMC1CLKSOURCE_PLLSAI1;
-    PeriphClkInit.PLLSAI1.PLLSAI1Source = RCC_PLLSOURCE_MSI;
-    PeriphClkInit.PLLSAI1.PLLSAI1M = 1;
-    PeriphClkInit.PLLSAI1.PLLSAI1N = 24;
-    PeriphClkInit.PLLSAI1.PLLSAI1P = RCC_PLLP_DIV7;
-    PeriphClkInit.PLLSAI1.PLLSAI1Q = RCC_PLLQ_DIV2;
-    PeriphClkInit.PLLSAI1.PLLSAI1R = RCC_PLLR_DIV2;
+    PeriphClkInit.PeriphClockSelection    = RCC_PERIPHCLK_SDMMC1;
+    PeriphClkInit.Sdmmc1ClockSelection    = RCC_SDMMC1CLKSOURCE_PLLSAI1;
+    PeriphClkInit.PLLSAI1.PLLSAI1Source   = RCC_PLLSOURCE_MSI;
+    PeriphClkInit.PLLSAI1.PLLSAI1M        = 1;
+    PeriphClkInit.PLLSAI1.PLLSAI1N        = 24;
+    PeriphClkInit.PLLSAI1.PLLSAI1P        = RCC_PLLP_DIV7;
+    PeriphClkInit.PLLSAI1.PLLSAI1Q        = RCC_PLLQ_DIV2;
+    PeriphClkInit.PLLSAI1.PLLSAI1R        = RCC_PLLR_DIV2;
     PeriphClkInit.PLLSAI1.PLLSAI1ClockOut = RCC_PLLSAI1_48M2CLK;
     if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
     {
@@ -495,7 +524,7 @@ void SystemClock_Config(void)
     }
 
     /* Configure the Systick */
-    HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/1000);
+    HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq() / 1000);
     HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_HCLK);
     HAL_NVIC_SetPriority(SysTick_IRQn, 0, 0);
 }
@@ -520,16 +549,16 @@ void HAL_MspInit(void)
 /*** Debug ***/
 void print(const char* str)
 {
-#if (USE_SWO_TRACE)
+#if(USE_SWO_TRACE)
     puts(str);
 #endif
 }
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @param  None
-  * @retval None
-  */
+ * @brief  This function is executed in case of error occurrence.
+ * @param  None
+ * @retval None
+ */
 void Error_Handler(void)
 {
     while(1)
@@ -542,15 +571,14 @@ void Error_Handler(void)
 #ifdef USE_FULL_ASSERT
 
 /**
-   * @brief Reports the name of the source file and the source line number
-   * where the assert_param error has occurred.
-   * @param file: pointer to the source file name
-   * @param line: assert_param error line source number
-   * @retval None
-   */
+ * @brief Reports the name of the source file and the source line number
+ * where the assert_param error has occurred.
+ * @param file: pointer to the source file name
+ * @param line: assert_param error line source number
+ * @retval None
+ */
 void assert_failed(uint8_t* file, uint32_t line)
 {
-
 }
 
 #endif

--- a/projects/STM32L476-CustomHw/source/sd_diskio.c
+++ b/projects/STM32L476-CustomHw/source/sd_diskio.c
@@ -1,23 +1,23 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   sd_diskio.c
-  * @brief  SD diskio driver
-  *	        This file contains the implementation of the SD diskio driver
-  *         used by the FatFs module. The driver uses the HAL library of ST.
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   sd_diskio.c
+ * @brief  SD diskio driver
+ *	       This file contains the implementation of the SD diskio driver
+ *         used by the FatFs module. The driver uses the HAL library of ST.
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "ff_gen_drv.h"
 #include "sd_diskio.h"
 
 /* Defines -------------------------------------------------------------------*/
-#define SD_TIMEOUT      SD_DATATIMEOUT      /* Defined in bsp_driver_sd.h */
+#define SD_TIMEOUT SD_DATATIMEOUT /* Defined in bsp_driver_sd.h */
 
 /*
  * Depending on the use case, the SD card initialization could be done at the
@@ -25,7 +25,7 @@
  * the BSP_SD_Init() call in the SD_Initialize() and manually add a call to
  * BSP_SD_Init() elsewhere in the application.
  */
-//#define ENABLE_SD_INIT
+// #define ENABLE_SD_INIT
 
 /* Enable the define below to use the SD driver with DMA.
  * The define has effect in SD_read and SD_write.
@@ -39,41 +39,36 @@
  * read and write operation.
  * Notice: This is applicable only for cortex M7 based platform.
  */
-//#define ENABLE_SD_DMA_CACHE_MAINTENANCE 1
+// #define ENABLE_SD_DMA_CACHE_MAINTENANCE 1
 
 /* Private variables ---------------------------------------------------------*/
-static volatile DSTATUS Stat = STA_NOINIT;      /* Disk status */
-static volatile UINT    ReadStatus = 0;
+static volatile DSTATUS Stat        = STA_NOINIT; /* Disk status */
+static volatile UINT    ReadStatus  = 0;
 static volatile UINT    WriteStatus = 0;
 
 /* Private function prototypes -----------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun);
-DSTATUS SD_initialize (BYTE);
-DSTATUS SD_status (BYTE);
-DRESULT SD_read (BYTE, BYTE*, DWORD, UINT);
+DSTATUS        SD_initialize(BYTE);
+DSTATUS        SD_status(BYTE);
+DRESULT        SD_read(BYTE, BYTE*, DWORD, UINT);
 
 #if _USE_WRITE == 1
-DRESULT SD_write (BYTE, const BYTE*, DWORD, UINT);
+DRESULT SD_write(BYTE, const BYTE*, DWORD, UINT);
 #endif /* _USE_WRITE == 1 */
 
 #if _USE_IOCTL == 1
-DRESULT SD_ioctl (BYTE, BYTE, void*);
-#endif  /* _USE_IOCTL == 1 */
+DRESULT SD_ioctl(BYTE, BYTE, void*);
+#endif /* _USE_IOCTL == 1 */
 
-
-const Diskio_drvTypeDef  SD_Driver =
-{
-    SD_initialize,
-    SD_status,
-    SD_read,
-#if  _USE_WRITE == 1
+const Diskio_drvTypeDef SD_Driver = {
+    SD_initialize, SD_status, SD_read,
+#if _USE_WRITE == 1
     SD_write,
 #endif /* _USE_WRITE == 1 */
-#if  _USE_IOCTL == 1
+#if _USE_IOCTL == 1
     SD_ioctl,
 #endif /* _USE_IOCTL == 1 */
 };
-
 
 /* Private functions ---------------------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun)
@@ -89,10 +84,10 @@ static DSTATUS SD_CheckStatus(BYTE lun)
 }
 
 /**
-  * @brief  Initializes a Drive
-  * @param  lun : not used
-  * @retval DSTATUS: Operation status
-  */
+ * @brief  Initializes a Drive
+ * @param  lun : not used
+ * @retval DSTATUS: Operation status
+ */
 DSTATUS SD_initialize(BYTE lun)
 {
     Stat = STA_NOINIT;
@@ -106,31 +101,31 @@ DSTATUS SD_initialize(BYTE lun)
     Stat = SD_CheckStatus(lun);
 #endif
 
-    ReadStatus = 0;
+    ReadStatus  = 0;
     WriteStatus = 0;
 
     return Stat;
 }
 
 /**
-  * @brief  Gets Disk Status
-  * @param  lun : not used
-  * @retval DSTATUS: Operation status
-  */
+ * @brief  Gets Disk Status
+ * @param  lun : not used
+ * @retval DSTATUS: Operation status
+ */
 DSTATUS SD_status(BYTE lun)
 {
     return SD_CheckStatus(lun);
 }
 
 /**
-  * @brief  Reads Sector(s)
-  * @param  lun : not used
-  * @param  *buff: Data buffer to store read data
-  * @param  sector: Sector address (LBA)
-  * @param  count: Number of sectors to read (1..128)
-  * @retval DRESULT: Operation result
-  */
-DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
+ * @brief  Reads Sector(s)
+ * @param  lun : not used
+ * @param  *buff: Data buffer to store read data
+ * @param  sector: Sector address (LBA)
+ * @param  count: Number of sectors to read (1..128)
+ * @retval DRESULT: Operation result
+ */
+DRESULT SD_read(BYTE lun, BYTE* buff, DWORD sector, UINT count)
 {
     DRESULT  res;
     uint32_t timeout;
@@ -142,10 +137,11 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
     uint32_t alignedAddr;
 #endif /* SD_DMA_CACHE_MAINTENANCE */
 
-    res = RES_ERROR;
+    res        = RES_ERROR;
     ReadStatus = 0;
 
-    if(BSP_SD_ReadBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) == MSD_OK)
+    if(BSP_SD_ReadBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) ==
+       MSD_OK)
     {
         /* Wait for DMA Complete */
         timeout = HAL_GetTick();
@@ -161,18 +157,21 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
         else
         {
             ReadStatus = 0;
-            timeout = HAL_GetTick();
+            timeout    = HAL_GetTick();
             while((HAL_GetTick() - timeout) < SD_TIMEOUT)
             {
                 if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
                 {
                     res = RES_OK;
 #if defined(ENABLE_SD_DMA_CACHE_MAINTENANCE)
-                    /* The SCB_InvalidateDCache_by_Addr() requires a 32-Byte aligned address,
-                     * adjust the address and the D-Cache size to invalidate accordingly.
-                    */
+                    /* The SCB_InvalidateDCache_by_Addr() requires a 32-Byte
+                     * aligned address, adjust the address and the D-Cache size
+                     * to invalidate accordingly.
+                     */
                     alignedAddr = (uint32_t)buff & ~0x1F;
-                    SCB_InvalidateDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+                    SCB_InvalidateDCache_by_Addr(
+                        (uint32_t*)alignedAddr,
+                        count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif /* SD_DMA_CACHE_MAINTENANCE */
                     break;
                 }
@@ -185,9 +184,8 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 #else
     /* Use SD Driver in blocking mode */
     res = RES_ERROR;
-    if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                         (uint32_t)(sector),
-                         count, SDMMC_HAL_TIMEOUT) == MSD_OK)
+    if(BSP_SD_ReadBlocks((uint32_t*)buff, (uint32_t)(sector), count,
+                         SDMMC_HAL_TIMEOUT) == MSD_OK)
     {
         /* Wait until the read operation is finished */
         timeout = HAL_GetTick();
@@ -204,17 +202,16 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 #endif /* ENABLE_SD_DMA_DRIVER */
 }
 
-
 /**
-  * @brief  Writes Sector(s)
-  * @param  lun : not used
-  * @param  *buff: Data to be written
-  * @param  sector: Sector address (LBA)
-  * @param  count: Number of sectors to write (1..128)
-  * @retval DRESULT: Operation result
-  */
+ * @brief  Writes Sector(s)
+ * @param  lun : not used
+ * @param  *buff: Data to be written
+ * @param  sector: Sector address (LBA)
+ * @param  count: Number of sectors to write (1..128)
+ * @retval DRESULT: Operation result
+ */
 #if _USE_WRITE == 1
-DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
+DRESULT SD_write(BYTE lun, const BYTE* buff, DWORD sector, UINT count)
 {
     DRESULT  res;
     uint32_t timeout;
@@ -224,14 +221,16 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 
 #if defined(ENABLE_SD_DMA_CACHE_MAINTENANCE)
     uint32_t alignedAddr;
-    alignedAddr = (uint32_t)buff &  ~0x1F;
-    SCB_CleanDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+    alignedAddr = (uint32_t)buff & ~0x1F;
+    SCB_CleanDCache_by_Addr((uint32_t*)alignedAddr,
+                            count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif
 
-    res = RES_ERROR;
+    res         = RES_ERROR;
     WriteStatus = 0;
 
-    if(BSP_SD_WriteBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) == MSD_OK)
+    if(BSP_SD_WriteBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) ==
+       MSD_OK)
     {
         /* Wait for DMA complete */
         timeout = HAL_GetTick();
@@ -247,7 +246,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
         else
         {
             WriteStatus = 0;
-            timeout = HAL_GetTick();
+            timeout     = HAL_GetTick();
             while((HAL_GetTick() - timeout) < SD_TIMEOUT)
             {
                 if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
@@ -264,9 +263,8 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 #else
     /* Use SD Driver in blocking mode */
     res = RES_ERROR;
-    if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                          (uint32_t)(sector),
-                          count, SDMMC_HAL_TIMEOUT) == MSD_OK)
+    if(BSP_SD_WriteBlocks((uint32_t*)buff, (uint32_t)(sector), count,
+                          SDMMC_HAL_TIMEOUT) == MSD_OK)
     {
         /* Wait until the Write operation is finished */
         timeout = HAL_GetTick();
@@ -285,75 +283,74 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 #endif /* _USE_WRITE == 1 */
 
 /**
-  * @brief  I/O control operation
-  * @param  lun : not used
-  * @param  cmd: Control code
-  * @param  *buff: Buffer to send/receive control data
-  * @retval DRESULT: Operation result
-  */
+ * @brief  I/O control operation
+ * @param  lun : not used
+ * @param  cmd: Control code
+ * @param  *buff: Buffer to send/receive control data
+ * @retval DRESULT: Operation result
+ */
 #if _USE_IOCTL == 1
-DRESULT SD_ioctl(BYTE lun, BYTE cmd, void *buff)
+DRESULT SD_ioctl(BYTE lun, BYTE cmd, void* buff)
 {
-  DRESULT res = RES_ERROR;
-  BSP_SD_CardInfo CardInfo;
+    DRESULT         res = RES_ERROR;
+    BSP_SD_CardInfo CardInfo;
 
-  if(Stat & STA_NOINIT)
-  {
-      return RES_NOTRDY;
-  }
+    if(Stat & STA_NOINIT)
+    {
+        return RES_NOTRDY;
+    }
 
-  switch(cmd)
-  {
-      /* Make sure that no pending write process */
-      case CTRL_SYNC :
-        res = RES_OK;
-        break;
+    switch(cmd)
+    {
+        /* Make sure that no pending write process */
+        case CTRL_SYNC:
+            res = RES_OK;
+            break;
 
-      /* Get number of sectors on the disk (DWORD) */
-      case GET_SECTOR_COUNT :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(DWORD*)buff = CardInfo.LogBlockNbr;
-        res = RES_OK;
-        break;
+        /* Get number of sectors on the disk (DWORD) */
+        case GET_SECTOR_COUNT:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(DWORD*)buff = CardInfo.LogBlockNbr;
+            res           = RES_OK;
+            break;
 
-      /* Get R/W sector size (WORD) */
-      case GET_SECTOR_SIZE :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(WORD*)buff = CardInfo.LogBlockSize;
-        res = RES_OK;
-        break;
+        /* Get R/W sector size (WORD) */
+        case GET_SECTOR_SIZE:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(WORD*)buff = CardInfo.LogBlockSize;
+            res          = RES_OK;
+            break;
 
-      /* Get erase block size in unit of sector (DWORD) */
-      case GET_BLOCK_SIZE :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(DWORD*)buff = CardInfo.LogBlockSize;
-        res = RES_OK;
-        break;
+        /* Get erase block size in unit of sector (DWORD) */
+        case GET_BLOCK_SIZE:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(DWORD*)buff = CardInfo.LogBlockSize;
+            res           = RES_OK;
+            break;
 
-      default:
-        res = RES_PARERR;
-  }
+        default:
+            res = RES_PARERR;
+    }
 
-  return res;
+    return res;
 }
 #endif /* _USE_IOCTL == 1 */
 
-
 /**
-  * @brief Rx Transfer complete callback
-  * @param hsd: SD handle
-  * @retval None
-  */
+ * @brief Rx Transfer complete callback
+ * @param hsd: SD handle
+ * @retval None
+ */
 void BSP_SD_ReadCpltCallback(void)
 {
     ReadStatus = 1;
 }
 
 /**
-  * @brief Tx Transfer complete callback
-  * @param hsd: SD handle
-  * @retval None
-  */
+ * @brief Tx Transfer complete callback
+ * @param hsd: SD handle
+ * @retval None
+ */
 void BSP_SD_WriteCpltCallback(void)
 {
     WriteStatus = 1;

--- a/projects/STM32L476-CustomHw/source/stm32l4xx_it.c
+++ b/projects/STM32L476-CustomHw/source/stm32l4xx_it.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   stm32l4xx_it.c
-  * @brief  Interrupt Service Routines
-  *	        This file contains the exception and peripheral interrupt handlers.
-  *
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   stm32l4xx_it.c
+ * @brief  Interrupt Service Routines
+ *	       This file contains the exception and peripheral interrupt handlers.
+ *
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32l4xx_hal.h"
@@ -25,16 +25,15 @@ extern SD_HandleTypeDef hsd1;
 /******************************************************************************/
 
 /**
-* @brief This function handles Non maskable interrupt.
-*/
+ * @brief This function handles Non maskable interrupt.
+ */
 void NMI_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Hard fault interrupt.
-*/
+ * @brief This function handles Hard fault interrupt.
+ */
 void HardFault_Handler(void)
 {
     while(1)
@@ -43,8 +42,8 @@ void HardFault_Handler(void)
 }
 
 /**
-* @brief This function handles Memory management fault.
-*/
+ * @brief This function handles Memory management fault.
+ */
 void MemManage_Handler(void)
 {
     while(1)
@@ -53,8 +52,8 @@ void MemManage_Handler(void)
 }
 
 /**
-* @brief This function handles Prefetch fault, memory access fault.
-*/
+ * @brief This function handles Prefetch fault, memory access fault.
+ */
 void BusFault_Handler(void)
 {
     while(1)
@@ -63,8 +62,8 @@ void BusFault_Handler(void)
 }
 
 /**
-* @brief This function handles Undefined instruction or illegal state.
-*/
+ * @brief This function handles Undefined instruction or illegal state.
+ */
 void UsageFault_Handler(void)
 {
     while(1)
@@ -73,32 +72,29 @@ void UsageFault_Handler(void)
 }
 
 /**
-* @brief This function handles System service call via SWI instruction.
-*/
+ * @brief This function handles System service call via SWI instruction.
+ */
 void SVC_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Debug monitor.
-*/
+ * @brief This function handles Debug monitor.
+ */
 void DebugMon_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Pendable request for system service.
-*/
+ * @brief This function handles Pendable request for system service.
+ */
 void PendSV_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles System tick timer.
-*/
+ * @brief This function handles System tick timer.
+ */
 void SysTick_Handler(void)
 {
     HAL_IncTick();
@@ -110,9 +106,9 @@ void SysTick_Handler(void)
 /******************************************************************************/
 
 /**
-* @brief DMA2 Channel5 ISR
-* @note  SDMMC DMA Tx, Rx
-*/
+ * @brief DMA2 Channel5 ISR
+ * @note  SDMMC DMA Tx, Rx
+ */
 void DMA2_Channel5_IRQHandler(void)
 {
     if((hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_READ_SINGLE_BLOCK)) ||
@@ -120,16 +116,18 @@ void DMA2_Channel5_IRQHandler(void)
     {
         HAL_DMA_IRQHandler(hsd1.hdmarx);
     }
-    else if((hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_SINGLE_BLOCK)) ||
-            (hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_MULTIPLE_BLOCK)))
+    else if((hsd1.Context ==
+             (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_SINGLE_BLOCK)) ||
+            (hsd1.Context ==
+             (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_MULTIPLE_BLOCK)))
     {
         HAL_DMA_IRQHandler(hsd1.hdmatx);
     }
 }
 
 /**
-* @brief SDMMC ISR
-*/
+ * @brief SDMMC ISR
+ */
 void SDMMC1_IRQHandler(void)
 {
     HAL_SD_IRQHandler(&hsd1);

--- a/projects/STM32L476-CustomHw/source/system_stm32l4xx.c
+++ b/projects/STM32L476-CustomHw/source/system_stm32l4xx.c
@@ -1,353 +1,369 @@
 /**
-  ******************************************************************************
-  * @file    system_stm32l4xx.c
-  * @author  MCD Application Team
-  * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
-  *
-  *   This file provides two functions and one global variable to be called from
-  *   user application:
-  *      - SystemInit(): This function is called at startup just after reset and
-  *                      before branch to main program. This call is made inside
-  *                      the "startup_stm32l4xx.s" file.
-  *
-  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
-  *                                  by the user application to setup the SysTick
-  *                                  timer or configure other parameters.
-  *
-  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
-  *                                 be called whenever the core clock is changed
-  *                                 during program execution.
-  *
-  *   After each device reset the MSI (4 MHz) is used as system clock source.
-  *   Then SystemInit() function is called, in "startup_stm32l4xx.s" file, to
-  *   configure the system clock before to branch to main program.
-  *
-  *   This file configures the system clock as follows:
-  *=============================================================================
-  *-----------------------------------------------------------------------------
-  *        System Clock source                    | MSI
-  *-----------------------------------------------------------------------------
-  *        SYSCLK(Hz)                             | 4000000
-  *-----------------------------------------------------------------------------
-  *        HCLK(Hz)                               | 4000000
-  *-----------------------------------------------------------------------------
-  *        AHB Prescaler                          | 1
-  *-----------------------------------------------------------------------------
-  *        APB1 Prescaler                         | 1
-  *-----------------------------------------------------------------------------
-  *        APB2 Prescaler                         | 1
-  *-----------------------------------------------------------------------------
-  *        PLL_M                                  | 1
-  *-----------------------------------------------------------------------------
-  *        PLL_N                                  | 8
-  *-----------------------------------------------------------------------------
-  *        PLL_P                                  | 7
-  *-----------------------------------------------------------------------------
-  *        PLL_Q                                  | 2
-  *-----------------------------------------------------------------------------
-  *        PLL_R                                  | 2
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_P                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_Q                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_R                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_P                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_Q                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_R                              | NA
-  *-----------------------------------------------------------------------------
-  *        Require 48MHz for USB OTG FS,          | Disabled
-  *        SDIO and RNG clock                     |
-  *-----------------------------------------------------------------------------
-  *=============================================================================
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+ *******************************************************************************
+ * @file    system_stm32l4xx.c
+ * @author  MCD Application Team
+ * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
+ *
+ *   This file provides two functions and one global variable to be called from
+ *   user application:
+ *      - SystemInit(): This function is called at startup just after reset and
+ *                      before branch to main program. This call is made inside
+ *                      the "startup_stm32l4xx.s" file.
+ *
+ *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be
+ *used by the user application to setup the SysTick timer or configure other
+ *parameters.
+ *
+ *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+ *                                 be called whenever the core clock is changed
+ *                                 during program execution.
+ *
+ *   After each device reset the MSI (4 MHz) is used as system clock source.
+ *   Then SystemInit() function is called, in "startup_stm32l4xx.s" file, to
+ *   configure the system clock before to branch to main program.
+ *
+ *   This file configures the system clock as follows:
+ *==============================================================================
+ *------------------------------------------------------------------------------
+ *        System Clock source                    | MSI
+ *------------------------------------------------------------------------------
+ *        SYSCLK(Hz)                             | 4000000
+ *------------------------------------------------------------------------------
+ *        HCLK(Hz)                               | 4000000
+ *------------------------------------------------------------------------------
+ *        AHB Prescaler                          | 1
+ *------------------------------------------------------------------------------
+ *        APB1 Prescaler                         | 1
+ *------------------------------------------------------------------------------
+ *        APB2 Prescaler                         | 1
+ *------------------------------------------------------------------------------
+ *        PLL_M                                  | 1
+ *------------------------------------------------------------------------------
+ *        PLL_N                                  | 8
+ *------------------------------------------------------------------------------
+ *        PLL_P                                  | 7
+ *------------------------------------------------------------------------------
+ *        PLL_Q                                  | 2
+ *------------------------------------------------------------------------------
+ *        PLL_R                                  | 2
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_P                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_Q                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_R                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_P                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_Q                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_R                              | NA
+ *------------------------------------------------------------------------------
+ *        Require 48MHz for USB OTG FS,          | Disabled
+ *        SDIO and RNG clock                     |
+ *------------------------------------------------------------------------------
+ *==============================================================================
+ *******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *notice, this list of conditions and the following disclaimer in the
+ *documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ *******************************************************************************
+ */
 
 /** @addtogroup CMSIS
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup stm32l4xx_system
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Includes
-  * @{
-  */
+ * @{
+ */
 
 #include "stm32l4xx.h"
 
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    8000000U  /*!< Value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+#if !defined(HSE_VALUE)
+#define HSE_VALUE 8000000U /*!< Value of the External oscillator in Hz */
+#endif                     /* HSE_VALUE */
 
-#if !defined  (MSI_VALUE)
-  #define MSI_VALUE    4000000U  /*!< Value of the Internal oscillator in Hz*/
-#endif /* MSI_VALUE */
+#if !defined(MSI_VALUE)
+#define MSI_VALUE 4000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                     /* MSI_VALUE */
 
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    16000000U /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
+#if !defined(HSI_VALUE)
+#define HSI_VALUE 16000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                      /* HSI_VALUE */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_TypesDefinitions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Defines
-  * @{
-  */
+ * @{
+ */
 
 /************************* Miscellaneous Configuration ************************/
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
-                                   This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET                       \
+    0x00 /*!< Vector Table base offset field. \
+              This value must be a multiple of 0x200. */
 /******************************************************************************/
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Macros
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Variables
-  * @{
-  */
-  /* The SystemCoreClock variable is updated in three ways:
-      1) by calling CMSIS function SystemCoreClockUpdate()
-      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
-      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
-         Note: If you use this function to configure the system clock; then there
-               is no need to call the 2 first functions listed above, since SystemCoreClock
-               variable is updated automatically.
-  */
-  uint32_t SystemCoreClock = 4000000U;
+ * @{
+ */
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock
+   frequency Note: If you use this function to configure the system clock; then
+   there is no need to call the 2 first functions listed above, since
+   SystemCoreClock variable is updated automatically.
+*/
+uint32_t SystemCoreClock = 4000000U;
 
-  const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
-  const uint8_t  APBPrescTable[8] =  {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
-  const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,  1000000U,  2000000U, \
-                                      4000000U, 8000000U, 16000000U, 24000000U, 32000000U, 48000000U};
+const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
+                                   1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
+const uint8_t  APBPrescTable[8]  = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
+const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,
+                                    1000000U,  2000000U,  4000000U,  8000000U,
+                                    16000000U, 24000000U, 32000000U, 48000000U};
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_FunctionPrototypes
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Functions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @brief  Setup the microcontroller system.
-  * @param  None
-  * @retval None
-  */
+ * @brief  Setup the microcontroller system.
+ * @param  None
+ * @retval None
+ */
 
 void SystemInit(void)
 {
-  /* FPU settings ------------------------------------------------------------*/
-  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
-  #endif
+/* FPU settings --------------------------------------------------------------*/
+#if(__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |=
+        ((3UL << 10 * 2) | (3UL << 11 * 2)); /* set CP10 and CP11 Full Access */
+#endif
 
-  /* Reset the RCC clock configuration to the default reset state ------------*/
-  /* Set MSION bit */
-  RCC->CR |= RCC_CR_MSION;
+    /* Reset the RCC clock configuration to the default reset state
+     * ------------*/
+    /* Set MSION bit */
+    RCC->CR |= RCC_CR_MSION;
 
-  /* Reset CFGR register */
-  RCC->CFGR = 0x00000000U;
+    /* Reset CFGR register */
+    RCC->CFGR = 0x00000000U;
 
-  /* Reset HSEON, CSSON , HSION, and PLLON bits */
-  RCC->CR &= 0xEAF6FFFFU;
+    /* Reset HSEON, CSSON , HSION, and PLLON bits */
+    RCC->CR &= 0xEAF6FFFFU;
 
-  /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x00001000U;
+    /* Reset PLLCFGR register */
+    RCC->PLLCFGR = 0x00001000U;
 
-  /* Reset HSEBYP bit */
-  RCC->CR &= 0xFFFBFFFFU;
+    /* Reset HSEBYP bit */
+    RCC->CR &= 0xFFFBFFFFU;
 
-  /* Disable all interrupts */
-  RCC->CIER = 0x00000000U;
+    /* Disable all interrupts */
+    RCC->CIER = 0x00000000U;
 
-  /* Configure the Vector Table location add offset address ------------------*/
+    /* Configure the Vector Table location add offset address
+     * ------------------*/
 #ifdef VECT_TAB_SRAM
-  SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+    SCB->VTOR = SRAM_BASE |
+                VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = FLASH_BASE |
+                VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 }
 
 /**
-  * @brief  Update SystemCoreClock variable according to Clock Register Values.
-  *         The SystemCoreClock variable contains the core clock (HCLK), it can
-  *         be used by the user application to setup the SysTick timer or configure
-  *         other parameters.
-  *
-  * @note   Each time the core clock (HCLK) changes, this function must be called
-  *         to update SystemCoreClock variable value. Otherwise, any configuration
-  *         based on this variable will be incorrect.
-  *
-  * @note   - The system frequency computed by this function is not the real
-  *           frequency in the chip. It is calculated based on the predefined
-  *           constant and the selected clock source:
-  *
-  *           - If SYSCLK source is MSI, SystemCoreClock will contain the MSI_VALUE(*)
-  *
-  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(**)
-  *
-  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(***)
-  *
-  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(***)
-  *             or HSI_VALUE(*) or MSI_VALUE(*) multiplied/divided by the PLL factors.
-  *
-  *         (*) MSI_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *             4 MHz) but the real value may vary depending on the variations
-  *             in voltage and temperature.
-  *
-  *         (**) HSI_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *              16 MHz) but the real value may vary depending on the variations
-  *              in voltage and temperature.
-  *
-  *         (***) HSE_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *              8 MHz), user has to ensure that HSE_VALUE is same as the real
-  *              frequency of the crystal used. Otherwise, this function may
-  *              have wrong result.
-  *
-  *         - The result of this function could be not correct when using fractional
-  *           value for HSE crystal.
-  *
-  * @param  None
-  * @retval None
-  */
+ * @brief  Update SystemCoreClock variable according to Clock Register Values.
+ *         The SystemCoreClock variable contains the core clock (HCLK), it can
+ *         be used by the user application to setup the SysTick timer or
+ * configure other parameters.
+ *
+ * @note   Each time the core clock (HCLK) changes, this function must be called
+ *         to update SystemCoreClock variable value. Otherwise, any
+ * configuration based on this variable will be incorrect.
+ *
+ * @note   - The system frequency computed by this function is not the real
+ *           frequency in the chip. It is calculated based on the predefined
+ *           constant and the selected clock source:
+ *
+ *           - If SYSCLK source is MSI, SystemCoreClock will contain the
+ * MSI_VALUE(*)
+ *
+ *           - If SYSCLK source is HSI, SystemCoreClock will contain the
+ * HSI_VALUE(**)
+ *
+ *           - If SYSCLK source is HSE, SystemCoreClock will contain the
+ * HSE_VALUE(***)
+ *
+ *           - If SYSCLK source is PLL, SystemCoreClock will contain the
+ * HSE_VALUE(***) or HSI_VALUE(*) or MSI_VALUE(*) multiplied/divided by the PLL
+ * factors.
+ *
+ *         (*) MSI_VALUE is a constant defined in stm32l4xx_hal.h file (default
+ * value 4 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (**) HSI_VALUE is a constant defined in stm32l4xx_hal.h file (default
+ * value 16 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (***) HSE_VALUE is a constant defined in stm32l4xx_hal.h file
+ * (default value 8 MHz), user has to ensure that HSE_VALUE is same as the real
+ *              frequency of the crystal used. Otherwise, this function may
+ *              have wrong result.
+ *
+ *         - The result of this function could be not correct when using
+ * fractional value for HSE crystal.
+ *
+ * @param  None
+ * @retval None
+ */
 void SystemCoreClockUpdate(void)
 {
-  uint32_t tmp = 0U, msirange = 0U, pllvco = 0U, pllr = 2U, pllsource = 0U, pllm = 2U;
+    uint32_t tmp = 0U, msirange = 0U, pllvco = 0U, pllr = 2U, pllsource = 0U,
+             pllm = 2U;
 
-  /* Get MSI Range frequency--------------------------------------------------*/
-  if((RCC->CR & RCC_CR_MSIRGSEL) == RESET)
-  { /* MSISRANGE from RCC_CSR applies */
-    msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> 8U;
-  }
-  else
-  { /* MSIRANGE from RCC_CR applies */
-    msirange = (RCC->CR & RCC_CR_MSIRANGE) >> 4U;
-  }
-  /*MSI frequency range in HZ*/
-  msirange = MSIRangeTable[msirange];
+    /* Get MSI Range
+     * frequency--------------------------------------------------*/
+    if((RCC->CR & RCC_CR_MSIRGSEL) == RESET)
+    { /* MSISRANGE from RCC_CSR applies */
+        msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> 8U;
+    }
+    else
+    { /* MSIRANGE from RCC_CR applies */
+        msirange = (RCC->CR & RCC_CR_MSIRANGE) >> 4U;
+    }
+    /*MSI frequency range in HZ*/
+    msirange = MSIRangeTable[msirange];
 
-  /* Get SYSCLK source -------------------------------------------------------*/
-  switch (RCC->CFGR & RCC_CFGR_SWS)
-  {
-    case 0x00:  /* MSI used as system clock source */
-      SystemCoreClock = msirange;
-      break;
+    /* Get SYSCLK source
+     * -------------------------------------------------------*/
+    switch(RCC->CFGR & RCC_CFGR_SWS)
+    {
+        case 0x00: /* MSI used as system clock source */
+            SystemCoreClock = msirange;
+            break;
 
-    case 0x04:  /* HSI used as system clock source */
-      SystemCoreClock = HSI_VALUE;
-      break;
+        case 0x04: /* HSI used as system clock source */
+            SystemCoreClock = HSI_VALUE;
+            break;
 
-    case 0x08:  /* HSE used as system clock source */
-      SystemCoreClock = HSE_VALUE;
-      break;
+        case 0x08: /* HSE used as system clock source */
+            SystemCoreClock = HSE_VALUE;
+            break;
 
-    case 0x0C:  /* PLL used as system clock  source */
-      /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
-         SYSCLK = PLL_VCO / PLLR
-         */
-      pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
-      pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4U) + 1U ;
+        case 0x0C: /* PLL used as system clock  source */
+            /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
+               SYSCLK = PLL_VCO / PLLR
+               */
+            pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+            pllm      = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4U) + 1U;
 
-      switch (pllsource)
-      {
-        case 0x02:  /* HSI used as PLL clock source */
-          pllvco = (HSI_VALUE / pllm);
-          break;
+            switch(pllsource)
+            {
+                case 0x02: /* HSI used as PLL clock source */
+                    pllvco = (HSI_VALUE / pllm);
+                    break;
 
-        case 0x03:  /* HSE used as PLL clock source */
-          pllvco = (HSE_VALUE / pllm);
-          break;
+                case 0x03: /* HSE used as PLL clock source */
+                    pllvco = (HSE_VALUE / pllm);
+                    break;
 
-        default:    /* MSI used as PLL clock source */
-          pllvco = (msirange / pllm);
-          break;
-      }
-      pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8U);
-      pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25U) + 1U) * 2U;
-      SystemCoreClock = pllvco/pllr;
-      break;
+                default: /* MSI used as PLL clock source */
+                    pllvco = (msirange / pllm);
+                    break;
+            }
+            pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8U);
+            pllr   = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25U) + 1U) * 2U;
+            SystemCoreClock = pllvco / pllr;
+            break;
 
-    default:
-      SystemCoreClock = msirange;
-      break;
-  }
-  /* Compute HCLK clock frequency --------------------------------------------*/
-  /* Get HCLK prescaler */
-  tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4U)];
-  /* HCLK clock frequency */
-  SystemCoreClock >>= tmp;
+        default:
+            SystemCoreClock = msirange;
+            break;
+    }
+    /* Compute HCLK clock frequency
+     * --------------------------------------------*/
+    /* Get HCLK prescaler */
+    tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4U)];
+    /* HCLK clock frequency */
+    SystemCoreClock >>= tmp;
 }
 
+/**
+ * @}
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
+ * @}
+ */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/projects/STM32L496-CustomHw/include/bsp_driver_sd.h
+++ b/projects/STM32L496-CustomHw/include/bsp_driver_sd.h
@@ -5,35 +5,44 @@
 #include "stm32l4xx_hal.h"
 
 /* Exported types ------------------------------------------------------------*/
-#define BSP_SD_CardInfo             HAL_SD_CardInfoTypeDef
+#define BSP_SD_CardInfo HAL_SD_CardInfoTypeDef
 
 /* Exported constants --------------------------------------------------------*/
-#define MSD_OK                      ((uint8_t)0x00)
-#define MSD_ERROR                   ((uint8_t)0x01)
-#define MSD_ERROR_SD_NOT_PRESENT    ((uint8_t)0x02)
+#define MSD_OK                   ((uint8_t)0x00)
+#define MSD_ERROR                ((uint8_t)0x01)
+#define MSD_ERROR_SD_NOT_PRESENT ((uint8_t)0x02)
 
-#define SD_TRANSFER_OK              ((uint8_t)0x00)
-#define SD_TRANSFER_BUSY            ((uint8_t)0x01)
-#define SD_TRANSFER_ERROR           ((uint8_t)0x02)
+#define SD_TRANSFER_OK    ((uint8_t)0x00)
+#define SD_TRANSFER_BUSY  ((uint8_t)0x01)
+#define SD_TRANSFER_ERROR ((uint8_t)0x02)
 
-#define SD_PRESENT                  ((uint8_t)0x01)
-#define SD_NOT_PRESENT              ((uint8_t)0x00)
+#define SD_PRESENT     ((uint8_t)0x01)
+#define SD_NOT_PRESENT ((uint8_t)0x00)
 
-#define SD_DATATIMEOUT              (150U)  /* ms */
+#define SD_DATATIMEOUT (150U) /* ms */
 
-#define SDMMC_IRQ_PRIO              1
-#define SD_DMA_IRQ_PRIO             2
+#define SDMMC_IRQ_PRIO  1
+#define SD_DMA_IRQ_PRIO 2
 
 /* Exported functions --------------------------------------------------------*/
 uint8_t BSP_SD_Init(void);
 uint8_t BSP_SD_DeInit(void);
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks);
-uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks);
+uint8_t BSP_SD_ReadBlocks(uint32_t* pData,
+                          uint32_t  ReadAddr,
+                          uint32_t  NumOfBlocks,
+                          uint32_t  Timeout);
+uint8_t BSP_SD_WriteBlocks(uint32_t* pData,
+                           uint32_t  WriteAddr,
+                           uint32_t  NumOfBlocks,
+                           uint32_t  Timeout);
+uint8_t
+        BSP_SD_ReadBlocks_DMA(uint32_t* pData, uint32_t ReadAddr, uint32_t NumOfBlocks);
+uint8_t BSP_SD_WriteBlocks_DMA(uint32_t* pData,
+                               uint32_t  WriteAddr,
+                               uint32_t  NumOfBlocks);
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr);
 uint8_t BSP_SD_GetCardState(void);
-void    BSP_SD_GetCardInfo(BSP_SD_CardInfo *CardInfo);
+void    BSP_SD_GetCardInfo(BSP_SD_CardInfo* CardInfo);
 uint8_t BSP_SD_IsDetected(void);
 
 __weak void BSP_SD_AbortCallback(void);

--- a/projects/STM32L496-CustomHw/include/fatfs.h
+++ b/projects/STM32L496-CustomHw/include/fatfs.h
@@ -2,7 +2,7 @@
 #define __fatfs_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/

--- a/projects/STM32L496-CustomHw/include/ffconf.h
+++ b/projects/STM32L496-CustomHw/include/ffconf.h
@@ -1,5 +1,5 @@
 #ifndef _FFCONF
-#define _FFCONF 68300	/* Revision ID */
+#define _FFCONF 68300 /* Revision ID */
 
 /*-----------------------------------------------------------------------------/
 / Additional user header to be used
@@ -11,13 +11,13 @@
 / Function Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _FS_READONLY        1      /* 0:Read/Write or 1:Read only */
+#define _FS_READONLY 1 /* 0:Read/Write or 1:Read only */
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
 /  and optional writing functions as well. */
 
-#define _FS_MINIMIZE        0      /* 0 to 3 */
+#define _FS_MINIMIZE 0 /* 0 to 3 */
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: All basic functions are enabled.
@@ -26,7 +26,7 @@
 /   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 /   3: f_lseek() function is removed in addition to 2. */
 
-#define _USE_STRFUNC        2      /* 0:Disable or 1-2:Enable */
+#define _USE_STRFUNC 2 /* 0:Disable or 1-2:Enable */
 /* This option switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -34,35 +34,37 @@
 /  1: Enable without LF-CRLF conversion.
 /  2: Enable with LF-CRLF conversion. */
 
-#define _USE_FIND           0
+#define _USE_FIND 0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
-#define _USE_MKFS           1
+#define _USE_MKFS 1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
-#define _USE_FASTSEEK       1
+#define _USE_FASTSEEK 1
 /* This option switches fast seek feature. (0:Disable or 1:Enable) */
 
-#define	_USE_EXPAND         0
+#define _USE_EXPAND 0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-#define _USE_CHMOD          0
-/* This option switches attribute manipulation functions, f_chmod() and f_utime().
-/  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this option. */
+#define _USE_CHMOD 0
+/* This option switches attribute manipulation functions, f_chmod() and
+f_utime().
+/  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this
+option. */
 
-#define _USE_LABEL          0
+#define _USE_LABEL 0
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 
-#define _USE_FORWARD        0
+#define _USE_FORWARD 0
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
 /*-----------------------------------------------------------------------------/
 / Locale and Namespace Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _CODE_PAGE          850
+#define _CODE_PAGE 850
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect setting of the code page can cause a file open failure.
 /
@@ -90,8 +92,8 @@
 /   950 - Traditional Chinese (DBCS)
 */
 
-#define _USE_LFN            1       /* 0 to 3 */
-#define _MAX_LFN            255     /* Maximum LFN length to handle (12 to 255) */
+#define _USE_LFN 1   /* 0 to 3 */
+#define _MAX_LFN 255 /* Maximum LFN length to handle (12 to 255) */
 /* The _USE_LFN switches the support of long file name (LFN).
 /
 /   0: Disable support of LFN. _MAX_LFN has no effect.
@@ -99,22 +101,23 @@
 /   2: Enable LFN with dynamic working buffer on the STACK.
 /   3: Enable LFN with dynamic working buffer on the HEAP.
 /
-/  To enable the LFN, Unicode handling functions (option/unicode.c) must be added
-/  to the project. The working buffer occupies (_MAX_LFN + 1) * 2 bytes and
-/  additional 608 bytes at exFAT enabled. _MAX_LFN can be in range from 12 to 255.
-/  It should be set 255 to support full featured LFN operations.
-/  When use stack for the working buffer, take care on stack overflow. When use heap
-/  memory for the working buffer, memory management functions, ff_memalloc() and
+/  To enable the LFN, Unicode handling functions (option/unicode.c) must be
+added /  to the project. The working buffer occupies (_MAX_LFN + 1) * 2 bytes
+and /  additional 608 bytes at exFAT enabled. _MAX_LFN can be in range from 12
+to 255. /  It should be set 255 to support full featured LFN operations. /  When
+use stack for the working buffer, take care on stack overflow. When use heap /
+memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree(), must be added to the project. */
 
-#define _LFN_UNICODE        0       /* 0:ANSI/OEM or 1:Unicode */
+#define _LFN_UNICODE 0 /* 0:ANSI/OEM or 1:Unicode */
 /* This option switches character encoding on the API. (0:ANSI/OEM or 1:UTF-16)
 /  To use Unicode string for the path name, enable LFN and set _LFN_UNICODE = 1.
 /  This option also affects behavior of string I/O functions. */
 
-#define _STRF_ENCODE        3
-/* When _LFN_UNICODE == 1, this option selects the character encoding ON THE FILE to
-/  be read/written via string I/O functions, f_gets(), f_putc(), f_puts and f_printf().
+#define _STRF_ENCODE 3
+/* When _LFN_UNICODE == 1, this option selects the character encoding ON THE
+FILE to /  be read/written via string I/O functions, f_gets(), f_putc(), f_puts
+and f_printf().
 /
 /  0: ANSI/OEM
 /  1: UTF-16LE
@@ -123,7 +126,7 @@
 /
 /  This option has no effect when _LFN_UNICODE == 0. */
 
-#define _FS_RPATH           0       /* 0 to 2 */
+#define _FS_RPATH 0 /* 0 to 2 */
 /* This option configures support of relative path.
 /
 /   0: Disable relative path and remove related functions.
@@ -135,41 +138,42 @@
 / Drive/Volume Configurations
 /----------------------------------------------------------------------------*/
 
-#define _VOLUMES            1
+#define _VOLUMES 1
 /* Number of volumes (logical drives) to be used. */
 
 /* USER CODE BEGIN Volumes */
-#define _STR_VOLUME_ID      0       /* 0:Use only 0-9 for drive ID, 1:Use strings for drive ID */
-#define _VOLUME_STRS        "RAM","NAND","CF","SD1","SD2","USB1","USB2","USB3"
+#define _STR_VOLUME_ID \
+    0 /* 0:Use only 0-9 for drive ID, 1:Use strings for drive ID */
+#define _VOLUME_STRS "RAM", "NAND", "CF", "SD1", "SD2", "USB1", "USB2", "USB3"
 /* _STR_VOLUME_ID switches string support of volume ID.
-/  When _STR_VOLUME_ID is set to 1, also pre-defined strings can be used as drive
-/  number in the path name. _VOLUME_STRS defines the drive ID strings for each
-/  logical drives. Number of items must be equal to _VOLUMES. Valid characters for
-/  the drive ID strings are: A-Z and 0-9. */
+/  When _STR_VOLUME_ID is set to 1, also pre-defined strings can be used as
+drive /  number in the path name. _VOLUME_STRS defines the drive ID strings for
+each /  logical drives. Number of items must be equal to _VOLUMES. Valid
+characters for /  the drive ID strings are: A-Z and 0-9. */
 /* USER CODE END Volumes */
 
-#define _MULTI_PARTITION    0       /* 0:Single partition, 1:Multiple partition */
+#define _MULTI_PARTITION 0 /* 0:Single partition, 1:Multiple partition */
 /* This option switches support of multi-partition on a physical drive.
 /  By default (0), each logical drive number is bound to the same physical drive
 /  number and only an FAT volume found on the physical drive will be mounted.
-/  When multi-partition is enabled (1), each logical drive number can be bound to
-/  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
-/  funciton will be available. */
-#define _MIN_SS             512     /* 512, 1024, 2048 or 4096 */
-#define _MAX_SS             512     /* 512, 1024, 2048 or 4096 */
+/  When multi-partition is enabled (1), each logical drive number can be bound
+to /  arbitrary physical drive and partition listed in the VolToPart[]. Also
+f_fdisk() /  funciton will be available. */
+#define _MIN_SS 512 /* 512, 1024, 2048 or 4096 */
+#define _MAX_SS 512 /* 512, 1024, 2048 or 4096 */
 /* These options configure the range of sector size to be supported. (512, 1024,
-/  2048 or 4096) Always set both 512 for most systems, all type of memory cards and
-/  harddisk. But a larger value may be required for on-board flash memory and some
-/  type of optical media. When _MAX_SS is larger than _MIN_SS, FatFs is configured
-/  to variable sector size and GET_SECTOR_SIZE command must be implemented to the
-/  disk_ioctl() function. */
+/  2048 or 4096) Always set both 512 for most systems, all type of memory cards
+and /  harddisk. But a larger value may be required for on-board flash memory
+and some /  type of optical media. When _MAX_SS is larger than _MIN_SS, FatFs is
+configured /  to variable sector size and GET_SECTOR_SIZE command must be
+implemented to the /  disk_ioctl() function. */
 
-#define	_USE_TRIM           0
+#define _USE_TRIM 0
 /* This option switches support of ATA-TRIM. (0:Disable or 1:Enable)
 /  To enable Trim function, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */
 
-#define _FS_NOFSINFO        0       /* 0,1,2 or 3 */
+#define _FS_NOFSINFO 0 /* 0,1,2 or 3 */
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.
@@ -184,44 +188,47 @@
 / System Configurations
 /----------------------------------------------------------------------------*/
 
-#define _FS_TINY            0       /* 0:Normal or 1:Tiny */
+#define _FS_TINY 0 /* 0:Normal or 1:Tiny */
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
-/  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS bytes.
-/  Instead of private sector buffer eliminated from the file object, common sector
-/  buffer in the file system object (FATFS) is used for the file data transfer. */
+/  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS
+bytes. /  Instead of private sector buffer eliminated from the file object,
+common sector /  buffer in the file system object (FATFS) is used for the file
+data transfer. */
 
-#define _FS_EXFAT	        0
+#define _FS_EXFAT 0
 /* This option switches support of exFAT file system. (0:Disable or 1:Enable)
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards C89 compatibility. */
 
-#define _FS_NORTC	        0
-#define _NORTC_MON	        6
-#define _NORTC_MDAY	        4
-#define _NORTC_YEAR	        2018
-/* The option _FS_NORTC switches timestamp functiton. If the system does not have
-/  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to disable
-/  the timestamp function. All objects modified by FatFs will have a fixed timestamp
-/  defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR in local time.
-/  To enable timestamp function (_FS_NORTC = 0), get_fattime() function need to be
-/  added to the project to get current time form real-time clock. _NORTC_MON,
-/  _NORTC_MDAY and _NORTC_YEAR have no effect.
-/  These options have no effect at read-only configuration (_FS_READONLY = 1). */
+#define _FS_NORTC   0
+#define _NORTC_MON  6
+#define _NORTC_MDAY 4
+#define _NORTC_YEAR 2018
+/* The option _FS_NORTC switches timestamp functiton. If the system does not
+have /  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to
+disable /  the timestamp function. All objects modified by FatFs will have a
+fixed timestamp /  defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR in local
+time. /  To enable timestamp function (_FS_NORTC = 0), get_fattime() function
+need to be /  added to the project to get current time form real-time clock.
+_NORTC_MON, /  _NORTC_MDAY and _NORTC_YEAR have no effect.
+/  These options have no effect at read-only configuration (_FS_READONLY = 1).
+*/
 
-#define _FS_LOCK            0       /* 0:Disable or >=1:Enable */
-/* The option _FS_LOCK switches file lock function to control duplicated file open
-/  and illegal operation to open objects. This option must be 0 when _FS_READONLY
-/  is 1.
+#define _FS_LOCK 0 /* 0:Disable or >=1:Enable */
+/* The option _FS_LOCK switches file lock function to control duplicated file
+open /  and illegal operation to open objects. This option must be 0 when
+_FS_READONLY /  is 1.
 /
-/  0:  Disable file lock function. To avoid volume corruption, application program
-/      should avoid illegal open, remove and rename to the open objects.
-/  >0: Enable file lock function. The value defines how many files/sub-directories
-/      can be opened simultaneously under file lock control. Note that the file
-/      lock control is independent of re-entrancy. */
+/  0:  Disable file lock function. To avoid volume corruption, application
+program /      should avoid illegal open, remove and rename to the open objects.
+/  >0: Enable file lock function. The value defines how many
+files/sub-directories /      can be opened simultaneously under file lock
+control. Note that the file /      lock control is independent of re-entrancy.
+*/
 
-#define _FS_REENTRANT       0       /* 0:Disable or 1:Enable */
-#define _FS_TIMEOUT         1000    /* Timeout period in unit of time ticks */
-#define _SYNC_t             osSemaphoreId
+#define _FS_REENTRANT 0    /* 0:Disable or 1:Enable */
+#define _FS_TIMEOUT   1000 /* Timeout period in unit of time ticks */
+#define _SYNC_t       osSemaphoreId
 /* The option _FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()
@@ -235,15 +242,15 @@
 /      option/syscall.c.
 /
 /  The _FS_TIMEOUT defines timeout period in unit of time tick.
-/  The _SYNC_t defines O/S dependent sync object type. e.g. HANDLE, ID, OS_EVENT*,
-/  SemaphoreHandle_t and etc.. A header file for O/S definitions needs to be
-/  included somewhere in the scope of ff.h. */
+/  The _SYNC_t defines O/S dependent sync object type. e.g. HANDLE, ID,
+OS_EVENT*, /  SemaphoreHandle_t and etc.. A header file for O/S definitions
+needs to be /  included somewhere in the scope of ff.h. */
 
 /* define the ff_malloc ff_free macros as standard malloc free */
 #if !defined(ff_malloc) && !defined(ff_free)
 #include <stdlib.h>
-#define ff_malloc  malloc
-#define ff_free  free
+#define ff_malloc malloc
+#define ff_free   free
 #endif
 
 #endif /* _FFCONF */

--- a/projects/STM32L496-CustomHw/include/main.h
+++ b/projects/STM32L496-CustomHw/include/main.h
@@ -2,44 +2,58 @@
 #define __MAIN_H
 
 /*** Application-Specific Configuration ***************************************/
-#define CONF_BUILD          "2018-04-18"    /* Bootloader build date [YYYY-MM-DD] */
-#define CONF_FILENAME       "GPP.bin"       /* File name of application located on SD card */
-
-#define USE_SWO_TRACE       1               /* For development/debugging: stdout/stderr via SWO trace */
+/* Bootloader build date [YYYY-MM-DD] */
+#define CONF_BUILD "2018-04-18"
+/* File name of application located on SD card */
+#define CONF_FILENAME "GPP.bin"
+/* For development/debugging: stdout/stderr via SWO trace */
+#define USE_SWO_TRACE 1
 /******************************************************************************/
 
 /* Hardware Defines ----------------------------------------------------------*/
-#define BTN_Port            GPIOB
-#define BTN_Pin             GPIO_PIN_8
+#define BTN_Port GPIOB
+#define BTN_Pin  GPIO_PIN_8
 
-#define LED_R_Port          GPIOB
-#define LED_R_Pin           GPIO_PIN_4
-#define LED_Y_Port          GPIOB
-#define LED_Y_Pin           GPIO_PIN_5
-#define LED_G_Port          GPIOB
-#define LED_G_Pin           GPIO_PIN_6
+#define LED_R_Port GPIOB
+#define LED_R_Pin  GPIO_PIN_4
+#define LED_Y_Port GPIOB
+#define LED_Y_Pin  GPIO_PIN_5
+#define LED_G_Port GPIOB
+#define LED_G_Pin  GPIO_PIN_6
 
-#define SD_PWR_Port         GPIOC
-#define SD_PWR_Pin          GPIO_PIN_7
+#define SD_PWR_Port GPIOC
+#define SD_PWR_Pin  GPIO_PIN_7
 
 /* Hardware Macros -----------------------------------------------------------*/
-#define SDCARD_ON()         HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_RESET)
-#define SDCARD_OFF()        HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_SET)
+#define SDCARD_ON()  HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_RESET)
+#define SDCARD_OFF() HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_SET)
 
-#define LED_G_ON()          HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_SET)
-#define LED_G_OFF()         HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_RESET)
-#define LED_G_TG()          HAL_GPIO_TogglePin(LED_G_Port, LED_G_Pin)
-#define LED_Y_ON()          HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_SET)
-#define LED_Y_OFF()         HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_RESET)
-#define LED_Y_TG()          HAL_GPIO_TogglePin(LED_Y_Port, LED_Y_Pin)
-#define LED_R_ON()          HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_SET)
-#define LED_R_OFF()         HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_RESET)
-#define LED_R_TG()          HAL_GPIO_TogglePin(LED_R_Port, LED_R_Pin)
+#define LED_G_ON()  HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_SET)
+#define LED_G_OFF() HAL_GPIO_WritePin(LED_G_Port, LED_G_Pin, GPIO_PIN_RESET)
+#define LED_G_TG()  HAL_GPIO_TogglePin(LED_G_Port, LED_G_Pin)
+#define LED_Y_ON()  HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_SET)
+#define LED_Y_OFF() HAL_GPIO_WritePin(LED_Y_Port, LED_Y_Pin, GPIO_PIN_RESET)
+#define LED_Y_TG()  HAL_GPIO_TogglePin(LED_Y_Port, LED_Y_Pin)
+#define LED_R_ON()  HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_SET)
+#define LED_R_OFF() HAL_GPIO_WritePin(LED_R_Port, LED_R_Pin, GPIO_PIN_RESET)
+#define LED_R_TG()  HAL_GPIO_TogglePin(LED_R_Port, LED_R_Pin)
 
-#define LED_ALL_ON()        do { LED_G_ON(); LED_Y_ON(); LED_R_ON(); } while(0)
-#define LED_ALL_OFF()       do { LED_G_OFF(); LED_Y_OFF(); LED_R_OFF(); } while(0)
+#define LED_ALL_ON() \
+    do               \
+    {                \
+        LED_G_ON();  \
+        LED_Y_ON();  \
+        LED_R_ON();  \
+    } while(0)
+#define LED_ALL_OFF() \
+    do                \
+    {                 \
+        LED_G_OFF();  \
+        LED_Y_OFF();  \
+        LED_R_OFF();  \
+    } while(0)
 
-#define IS_BTN_PRESSED()    ((HAL_GPIO_ReadPin(BTN_Port, BTN_Pin) == GPIO_PIN_RESET) ? 1 : 0)
-
+#define IS_BTN_PRESSED() \
+    ((HAL_GPIO_ReadPin(BTN_Port, BTN_Pin) == GPIO_PIN_RESET) ? 1 : 0)
 
 #endif /* __MAIN_H */

--- a/projects/STM32L496-CustomHw/include/stm32l4xx_hal_conf.h
+++ b/projects/STM32L496-CustomHw/include/stm32l4xx_hal_conf.h
@@ -2,7 +2,7 @@
 #define __STM32L4xx_HAL_CONF_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #include "main.h"
@@ -10,7 +10,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 /* ######################### Custom Definitions ############################# */
-#define SDMMC_HAL_TIMEOUT   500     /* [ms] */
+#define SDMMC_HAL_TIMEOUT 500 /* [ms] */
 
 /* ########################## Module Selection ############################## */
 #define HAL_MODULE_ENABLED
@@ -62,107 +62,120 @@
 //#define HAL_USART_MODULE_ENABLED
 //#define HAL_WWDG_MODULE_ENABLED
 
-/* ########################## Oscillator Values adaptation ####################*/
+/* ######################### Oscillator Values adaptation ####################*/
 /**
-  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
-  *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSE is used as system clock source, directly or through the PLL).
-  */
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+ * @brief Adjust the value of External High Speed oscillator (HSE) used in your
+ * application. This value is used by the RCC HAL module to compute the system
+ * frequency (when HSE is used as system clock source, directly or through the
+ * PLL).
+ */
+#if !defined(HSE_VALUE)
+#define HSE_VALUE \
+    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
+#endif                   /* HSE_VALUE */
 
-#if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100U)   /*!< Time out for HSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
-
-/**
-  * @brief Internal Multiple Speed oscillator (MSI) default value.
-  *        This value is the default MSI range value after Reset.
-  */
-#if !defined  (MSI_VALUE)
-  #define MSI_VALUE    ((uint32_t)4000000U) /*!< Value of the Internal oscillator in Hz*/
-#endif /* MSI_VALUE */
-/**
-  * @brief Internal High Speed oscillator (HSI) value.
-  *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSI is used as system clock source, directly or through the PLL).
-  */
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
+#if !defined(HSE_STARTUP_TIMEOUT)
+#define HSE_STARTUP_TIMEOUT \
+    ((uint32_t)100U) /*!< Time out for HSE start up, in ms */
+#endif               /* HSE_STARTUP_TIMEOUT */
 
 /**
-  * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and RNG.
-  *        This internal oscillator is mainly dedicated to provide a high precision clock to
-  *        the USB peripheral by means of a special Clock Recovery System (CRS) circuitry.
-  *        When the CRS is not used, the HSI48 RC oscillator runs on it default frequency
-  *        which is subject to manufacturing process variations.
-  */
-#if !defined  (HSI48_VALUE)
- #define HSI48_VALUE   ((uint32_t)48000000U) /*!< Value of the Internal High Speed oscillator for USB FS/SDMMC/RNG in Hz.
-                                              The real value my vary depending on manufacturing process variations.*/
-#endif /* HSI48_VALUE */
+ * @brief Internal Multiple Speed oscillator (MSI) default value.
+ *        This value is the default MSI range value after Reset.
+ */
+#if !defined(MSI_VALUE)
+#define MSI_VALUE \
+    ((uint32_t)4000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif                   /* MSI_VALUE */
+/**
+ * @brief Internal High Speed oscillator (HSI) value.
+ *        This value is used by the RCC HAL module to compute the system
+ * frequency (when HSI is used as system clock source, directly or through the
+ * PLL).
+ */
+#if !defined(HSI_VALUE)
+#define HSI_VALUE \
+    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif                    /* HSI_VALUE */
 
 /**
-  * @brief Internal Low Speed oscillator (LSI) value.
-  */
-#if !defined  (LSI_VALUE)
- #define LSI_VALUE  ((uint32_t)32000U)       /*!< LSI Typical Value in Hz*/
-#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
-                                             The real value may vary depending on the variations
-                                             in voltage and temperature.*/
+ * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and
+ * RNG. This internal oscillator is mainly dedicated to provide a high precision
+ * clock to the USB peripheral by means of a special Clock Recovery System (CRS)
+ * circuitry. When the CRS is not used, the HSI48 RC oscillator runs on it
+ * default frequency which is subject to manufacturing process variations.
+ */
+#if !defined(HSI48_VALUE)
+#define HSI48_VALUE                                                            \
+    ((uint32_t)48000000U) /*!< Value of the Internal High Speed oscillator for \
+                           USB FS/SDMMC/RNG in Hz. The real value my vary      \
+                           depending on manufacturing process variations.*/
+#endif                    /* HSI48_VALUE */
 
 /**
-  * @brief External Low Speed oscillator (LSE) value.
-  *        This value is used by the UART, RTC HAL module to compute the system frequency
-  */
-#if !defined  (LSE_VALUE)
-  #define LSE_VALUE    ((uint32_t)32768U) /*!< Value of the External oscillator in Hz*/
-#endif /* LSE_VALUE */
-
-#if !defined  (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000U)   /*!< Time out for LSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
+ * @brief Internal Low Speed oscillator (LSI) value.
+ */
+#if !defined(LSI_VALUE)
+#define LSI_VALUE ((uint32_t)32000U) /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
+                        The real value may vary depending on the variations  \
+                        in voltage and temperature.*/
 
 /**
-  * @brief External clock source for SAI1 peripheral
-  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
-  *        frequency.
-  */
-#if !defined  (EXTERNAL_SAI1_CLOCK_VALUE)
-  #define EXTERNAL_SAI1_CLOCK_VALUE    ((uint32_t)2097000U) /*!< Value of the SAI1 External clock source in Hz*/
-#endif /* EXTERNAL_SAI1_CLOCK_VALUE */
+ * @brief External Low Speed oscillator (LSE) value.
+ *        This value is used by the UART, RTC HAL module to compute the system
+ * frequency
+ */
+#if !defined(LSE_VALUE)
+#define LSE_VALUE \
+    ((uint32_t)32768U) /*!< Value of the External oscillator in Hz*/
+#endif                 /* LSE_VALUE */
+
+#if !defined(LSE_STARTUP_TIMEOUT)
+#define LSE_STARTUP_TIMEOUT \
+    ((uint32_t)5000U) /*!< Time out for LSE start up, in ms */
+#endif                /* HSE_STARTUP_TIMEOUT */
 
 /**
-  * @brief External clock source for SAI2 peripheral
-  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
-  *        frequency.
-  */
-#if !defined  (EXTERNAL_SAI2_CLOCK_VALUE)
-  #define EXTERNAL_SAI2_CLOCK_VALUE    ((uint32_t)2097000U) /*!< Value of the SAI2 External clock source in Hz*/
-#endif /* EXTERNAL_SAI2_CLOCK_VALUE */
+ * @brief External clock source for SAI1 peripheral
+ *        This value is used by the RCC HAL module to compute the SAI1 & SAI2
+ * clock source frequency.
+ */
+#if !defined(EXTERNAL_SAI1_CLOCK_VALUE)
+#define EXTERNAL_SAI1_CLOCK_VALUE \
+    ((uint32_t)2097000U) /*!< Value of the SAI1 External clock source in Hz*/
+#endif                   /* EXTERNAL_SAI1_CLOCK_VALUE */
+
+/**
+ * @brief External clock source for SAI2 peripheral
+ *        This value is used by the RCC HAL module to compute the SAI1 & SAI2
+ * clock source frequency.
+ */
+#if !defined(EXTERNAL_SAI2_CLOCK_VALUE)
+#define EXTERNAL_SAI2_CLOCK_VALUE \
+    ((uint32_t)2097000U) /*!< Value of the SAI2 External clock source in Hz*/
+#endif                   /* EXTERNAL_SAI2_CLOCK_VALUE */
 
 /* Tip: To avoid modifying this file each time you need to use different HSE,
    ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
 /* ########################### System Configuration ######################### */
 /**
-  * @brief This is the HAL system configuration section
-  */
+ * @brief This is the HAL system configuration section
+ */
 
-#define  VDD_VALUE                  ((uint32_t)3000U) /*!< Value of VDD in mv */
-#define  TICK_INT_PRIORITY          ((uint32_t)0U)    /*!< tick interrupt priority */
-#define  USE_RTOS                   0U
-#define  PREFETCH_ENABLE            0U
-#define  INSTRUCTION_CACHE_ENABLE   1U
-#define  DATA_CACHE_ENABLE          1U
+#define VDD_VALUE                ((uint32_t)3000U) /*!< Value of VDD in mv */
+#define TICK_INT_PRIORITY        ((uint32_t)0U) /*!< tick interrupt priority */
+#define USE_RTOS                 0U
+#define PREFETCH_ENABLE          0U
+#define INSTRUCTION_CACHE_ENABLE 1U
+#define DATA_CACHE_ENABLE        1U
 
 /* ########################## Assert Selection ############################## */
 /**
-  * @brief Uncomment the line below to expanse the "assert_param" macro in the
-  *        HAL drivers code
-  */
+ * @brief Uncomment the line below to expanse the "assert_param" macro in the
+ *        HAL drivers code
+ */
 /* #define USE_FULL_ASSERT    1U */
 
 /* ################## SPI peripheral configuration ########################## */
@@ -172,214 +185,215 @@
  * Deactivated: CRC code cleaned from driver
  */
 
-#define USE_SPI_CRC                 0U
+#define USE_SPI_CRC 0U
 
 /* Includes ------------------------------------------------------------------*/
 /**
-  * @brief Include module's header file
-  */
+ * @brief Include module's header file
+ */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-  #include "stm32l4xx_hal_rcc.h"
-  #include "stm32l4xx_hal_rcc_ex.h"
+#include "stm32l4xx_hal_rcc.h"
+#include "stm32l4xx_hal_rcc_ex.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-  #include "stm32l4xx_hal_gpio.h"
+#include "stm32l4xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-  #include "stm32l4xx_hal_dma.h"
-  #include "stm32l4xx_hal_dma_ex.h"
+#include "stm32l4xx_hal_dma.h"
+#include "stm32l4xx_hal_dma_ex.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
 
 #ifdef HAL_DFSDM_MODULE_ENABLED
-  #include "stm32l4xx_hal_dfsdm.h"
+#include "stm32l4xx_hal_dfsdm.h"
 #endif /* HAL_DFSDM_MODULE_ENABLED */
 
 #ifdef HAL_CORTEX_MODULE_ENABLED
-  #include "stm32l4xx_hal_cortex.h"
+#include "stm32l4xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-  #include "stm32l4xx_hal_adc.h"
+#include "stm32l4xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_CAN_MODULE_ENABLED
-  #include "stm32l4xx_hal_can.h"
+#include "stm32l4xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-  #include "stm32l4xx_hal_comp.h"
+#include "stm32l4xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-  #include "stm32l4xx_hal_crc.h"
+#include "stm32l4xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_CRYP_MODULE_ENABLED
-  #include "stm32l4xx_hal_cryp.h"
+#include "stm32l4xx_hal_cryp.h"
 #endif /* HAL_CRYP_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-  #include "stm32l4xx_hal_dac.h"
+#include "stm32l4xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_DCMI_MODULE_ENABLED
-  #include "stm32l4xx_hal_dcmi.h"
+#include "stm32l4xx_hal_dcmi.h"
 #endif /* HAL_DCMI_MODULE_ENABLED */
 
 #ifdef HAL_DMA2D_MODULE_ENABLED
-  #include "stm32l4xx_hal_dma2d.h"
+#include "stm32l4xx_hal_dma2d.h"
 #endif /* HAL_DMA2D_MODULE_ENABLED */
 
 #ifdef HAL_DSI_MODULE_ENABLED
-  #include "stm32l4xx_hal_dsi.h"
+#include "stm32l4xx_hal_dsi.h"
 #endif /* HAL_DSI_MODULE_ENABLED */
 
 #ifdef HAL_FIREWALL_MODULE_ENABLED
-  #include "stm32l4xx_hal_firewall.h"
+#include "stm32l4xx_hal_firewall.h"
 #endif /* HAL_FIREWALL_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-  #include "stm32l4xx_hal_flash.h"
+#include "stm32l4xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_HASH_MODULE_ENABLED
-  #include "stm32l4xx_hal_hash.h"
+#include "stm32l4xx_hal_hash.h"
 #endif /* HAL_HASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-  #include "stm32l4xx_hal_sram.h"
+#include "stm32l4xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-  #include "stm32l4xx_hal_nor.h"
+#include "stm32l4xx_hal_nor.h"
 #endif /* HAL_NOR_MODULE_ENABLED */
 
 #ifdef HAL_NAND_MODULE_ENABLED
-  #include "stm32l4xx_hal_nand.h"
+#include "stm32l4xx_hal_nand.h"
 #endif /* HAL_NAND_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
-  #include "stm32l4xx_hal_i2c.h"
+#include "stm32l4xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-  #include "stm32l4xx_hal_iwdg.h"
+#include "stm32l4xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_LCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_lcd.h"
+#include "stm32l4xx_hal_lcd.h"
 #endif /* HAL_LCD_MODULE_ENABLED */
 
 #ifdef HAL_LPTIM_MODULE_ENABLED
-  #include "stm32l4xx_hal_lptim.h"
+#include "stm32l4xx_hal_lptim.h"
 #endif /* HAL_LPTIM_MODULE_ENABLED */
 
 #ifdef HAL_LTDC_MODULE_ENABLED
-  #include "stm32l4xx_hal_ltdc.h"
+#include "stm32l4xx_hal_ltdc.h"
 #endif /* HAL_LTDC_MODULE_ENABLED */
 
 #ifdef HAL_OPAMP_MODULE_ENABLED
-  #include "stm32l4xx_hal_opamp.h"
+#include "stm32l4xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_OSPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_ospi.h"
+#include "stm32l4xx_hal_ospi.h"
 #endif /* HAL_OSPI_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-  #include "stm32l4xx_hal_pwr.h"
+#include "stm32l4xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_QSPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_qspi.h"
+#include "stm32l4xx_hal_qspi.h"
 #endif /* HAL_QSPI_MODULE_ENABLED */
 
 #ifdef HAL_RNG_MODULE_ENABLED
-  #include "stm32l4xx_hal_rng.h"
+#include "stm32l4xx_hal_rng.h"
 #endif /* HAL_RNG_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-  #include "stm32l4xx_hal_rtc.h"
+#include "stm32l4xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SAI_MODULE_ENABLED
-  #include "stm32l4xx_hal_sai.h"
+#include "stm32l4xx_hal_sai.h"
 #endif /* HAL_SAI_MODULE_ENABLED */
 
 #ifdef HAL_SD_MODULE_ENABLED
-  #include "stm32l4xx_hal_sd.h"
+#include "stm32l4xx_hal_sd.h"
 #endif /* HAL_SD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
-  #include "stm32l4xx_hal_smbus.h"
+#include "stm32l4xx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_spi.h"
+#include "stm32l4xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_SWPMI_MODULE_ENABLED
-  #include "stm32l4xx_hal_swpmi.h"
+#include "stm32l4xx_hal_swpmi.h"
 #endif /* HAL_SWPMI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-  #include "stm32l4xx_hal_tim.h"
+#include "stm32l4xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-  #include "stm32l4xx_hal_tsc.h"
+#include "stm32l4xx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-  #include "stm32l4xx_hal_uart.h"
+#include "stm32l4xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-  #include "stm32l4xx_hal_usart.h"
+#include "stm32l4xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-  #include "stm32l4xx_hal_irda.h"
+#include "stm32l4xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-  #include "stm32l4xx_hal_smartcard.h"
+#include "stm32l4xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-  #include "stm32l4xx_hal_wwdg.h"
+#include "stm32l4xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_pcd.h"
+#include "stm32l4xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_HCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_hcd.h"
+#include "stm32l4xx_hal_hcd.h"
 #endif /* HAL_HCD_MODULE_ENABLED */
 
 #ifdef HAL_GFXMMU_MODULE_ENABLED
-  #include "stm32l4xx_hal_gfxmmu.h"
+#include "stm32l4xx_hal_gfxmmu.h"
 #endif /* HAL_GFXMMU_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 /**
-  * @brief  The assert_param macro is used for function's parameters check.
-  * @param  expr: If expr is false, it calls assert_failed function
-  *         which reports the name of the source file and the source
-  *         line number of the call that failed.
-  *         If expr is true, it returns no value.
-  * @retval None
-  */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+ * @brief  The assert_param macro is used for function's parameters check.
+ * @param  expr: If expr is false, it calls assert_failed function
+ *         which reports the name of the source file and the source
+ *         line number of the call that failed.
+ *         If expr is true, it returns no value.
+ * @retval None
+ */
+#define assert_param(expr) \
+    ((expr) ? (void)0U : assert_failed((uint8_t*)__FILE__, __LINE__))
 /* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+void assert_failed(uint8_t* file, uint32_t line);
 #else
-  #define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */
 
 #ifdef __cplusplus

--- a/projects/STM32L496-CustomHw/include/stm32l4xx_it.h
+++ b/projects/STM32L496-CustomHw/include/stm32l4xx_it.h
@@ -2,7 +2,7 @@
 #define __STM32L4xx_IT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/

--- a/projects/STM32L496-CustomHw/source/bsp_driver_sd.c
+++ b/projects/STM32L496-CustomHw/source/bsp_driver_sd.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   bsp_driver_sd.c
-  * @brief  SD BSP driver
-  *	        This file contains the implementation of the SD BSP driver used by
-  *         the FatFs module. The driver uses the HAL library of ST.
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   bsp_driver_sd.c
+ * @brief  SD BSP driver
+ *	       This file contains the implementation of the SD BSP driver used by
+ *         the FatFs module. The driver uses the HAL library of ST.
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "bsp_driver_sd.h"
 
@@ -19,38 +19,38 @@
 SD_HandleTypeDef hsd1;
 
 /* Private function prototypes -----------------------------------------------*/
-static void BSP_SD_MspInit(void);
-static void BSP_SD_MspDeInit(void);
-static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd);
-static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef *hsd);
+static void              BSP_SD_MspInit(void);
+static void              BSP_SD_MspDeInit(void);
+static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef* hsd);
+static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef* hsd);
 
 /* External function prototypes ----------------------------------------------*/
 void Error_Handler(void);
 
 /**
-  * @brief  Initializes the SD card device.
-  * @retval SD status
-  */
+ * @brief  Initializes the SD card device.
+ * @retval SD status
+ */
 uint8_t BSP_SD_Init(void)
 {
     uint8_t tries;
 
     /* Check if the SD card is plugged in the slot */
-    if (BSP_SD_IsDetected() != SD_PRESENT)
+    if(BSP_SD_IsDetected() != SD_PRESENT)
     {
         return MSD_ERROR_SD_NOT_PRESENT;
     }
 
     /* SD interface configuration */
-    hsd1.Instance = SDMMC1;
-    hsd1.Init.ClockEdge = SDMMC_CLOCK_EDGE_RISING;
-    hsd1.Init.ClockBypass = SDMMC_CLOCK_BYPASS_DISABLE;
-    hsd1.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE;
-    hsd1.Init.BusWide = SDMMC_BUS_WIDE_1B;
+    hsd1.Instance                 = SDMMC1;
+    hsd1.Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
+    hsd1.Init.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
+    hsd1.Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
+    hsd1.Init.BusWide             = SDMMC_BUS_WIDE_1B;
     hsd1.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_ENABLE;
-    hsd1.Init.ClockDiv = 0;
+    hsd1.Init.ClockDiv            = 0;
 
-    for(tries=0; tries<5; ++tries)
+    for(tries = 0; tries < 5; ++tries)
     {
         /* Msp SD initialization */
         BSP_SD_MspDeInit();
@@ -77,9 +77,9 @@ uint8_t BSP_SD_Init(void)
 }
 
 /**
-  * @brief  De-Initializes the SD card device
-  * @retval None
-  */
+ * @brief  De-Initializes the SD card device
+ * @retval None
+ */
 uint8_t BSP_SD_DeInit(void)
 {
     /* HAL SD de-initialization */
@@ -93,42 +93,47 @@ uint8_t BSP_SD_DeInit(void)
     __HAL_RCC_SDMMC1_RELEASE_RESET();
 
     /* Misc */
-    hsd1.State = HAL_SD_STATE_RESET;
-    hsd1.Context = 0;
-    hsd1.ErrorCode = 0;
-    hsd1.SdCard.CardType = 0;
-    hsd1.SdCard.CardVersion = 0;
-    hsd1.SdCard.Class = 0;
-    hsd1.SdCard.RelCardAdd = 0;
-    hsd1.SdCard.BlockNbr = 0;
-    hsd1.SdCard.BlockSize = 0;
-    hsd1.SdCard.LogBlockNbr = 0;
+    hsd1.State               = HAL_SD_STATE_RESET;
+    hsd1.Context             = 0;
+    hsd1.ErrorCode           = 0;
+    hsd1.SdCard.CardType     = 0;
+    hsd1.SdCard.CardVersion  = 0;
+    hsd1.SdCard.Class        = 0;
+    hsd1.SdCard.RelCardAdd   = 0;
+    hsd1.SdCard.BlockNbr     = 0;
+    hsd1.SdCard.BlockSize    = 0;
+    hsd1.SdCard.LogBlockNbr  = 0;
     hsd1.SdCard.LogBlockSize = 0;
-    hsd1.CSD[0] = 0;
-    hsd1.CSD[1] = 0;
-    hsd1.CSD[2] = 0;
-    hsd1.CSD[3] = 0;
-    hsd1.CID[0] = 0;
-    hsd1.CID[1] = 0;
-    hsd1.CID[2] = 0;
-    hsd1.CID[3] = 0;
+    hsd1.CSD[0]              = 0;
+    hsd1.CSD[1]              = 0;
+    hsd1.CSD[2]              = 0;
+    hsd1.CSD[3]              = 0;
+    hsd1.CID[0]              = 0;
+    hsd1.CID[1]              = 0;
+    hsd1.CID[2]              = 0;
+    hsd1.CID[3]              = 0;
 
-    return  MSD_OK;
+    return MSD_OK;
 }
 
 /**
-  * @brief  Reads block(s) from a specified address in an SD card, in polling mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  ReadAddr: Address from where data is to be read
-  * @param  NumOfBlocks: Number of SD blocks to read
-  * @param  Timeout: Timeout for read operation
-  * @retval SD status
-  */
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout)
+ * @brief  Reads block(s) from a specified address in an SD card, in polling
+ * mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  ReadAddr: Address from where data is to be read
+ * @param  NumOfBlocks: Number of SD blocks to read
+ * @param  Timeout: Timeout for read operation
+ * @retval SD status
+ */
+uint8_t BSP_SD_ReadBlocks(uint32_t* pData,
+                          uint32_t  ReadAddr,
+                          uint32_t  NumOfBlocks,
+                          uint32_t  Timeout)
 {
     uint8_t sd_state = MSD_OK;
 
-    if(HAL_SD_ReadBlocks(&hsd1, (uint8_t *)pData, ReadAddr, NumOfBlocks, Timeout) != HAL_OK)
+    if(HAL_SD_ReadBlocks(&hsd1, (uint8_t*)pData, ReadAddr, NumOfBlocks,
+                         Timeout) != HAL_OK)
     {
         sd_state = MSD_ERROR;
     }
@@ -137,18 +142,23 @@ uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBloc
 }
 
 /**
-  * @brief  Writes block(s) to a specified address in an SD card, in polling mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
-  * @param  NumOfBlocks: Number of SD blocks to write
-  * @param  Timeout: Timeout for write operation
-  * @retval SD status
-  */
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout)
+ * @brief  Writes block(s) to a specified address in an SD card, in polling
+ * mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  WriteAddr: Address from where data is to be written
+ * @param  NumOfBlocks: Number of SD blocks to write
+ * @param  Timeout: Timeout for write operation
+ * @retval SD status
+ */
+uint8_t BSP_SD_WriteBlocks(uint32_t* pData,
+                           uint32_t  WriteAddr,
+                           uint32_t  NumOfBlocks,
+                           uint32_t  Timeout)
 {
     uint8_t sd_state = MSD_OK;
 
-    if(HAL_SD_WriteBlocks(&hsd1, (uint8_t *)pData, WriteAddr, NumOfBlocks, Timeout) != HAL_OK)
+    if(HAL_SD_WriteBlocks(&hsd1, (uint8_t*)pData, WriteAddr, NumOfBlocks,
+                          Timeout) != HAL_OK)
     {
         sd_state = MSD_ERROR;
     }
@@ -157,13 +167,14 @@ uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBl
 }
 
 /**
-  * @brief  Reads block(s) from a specified address in an SD card, in DMA mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  ReadAddr: Address from where data is to be read
-  * @param  NumOfBlocks: Number of SD blocks to read
-  * @retval SD status
-  */
-uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks)
+ * @brief  Reads block(s) from a specified address in an SD card, in DMA mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  ReadAddr: Address from where data is to be read
+ * @param  NumOfBlocks: Number of SD blocks to read
+ * @retval SD status
+ */
+uint8_t
+BSP_SD_ReadBlocks_DMA(uint32_t* pData, uint32_t ReadAddr, uint32_t NumOfBlocks)
 {
     HAL_StatusTypeDef sd_state = HAL_OK;
 
@@ -176,20 +187,23 @@ uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOf
     if(sd_state == HAL_OK)
     {
         /* Read block(s) in DMA transfer mode */
-        sd_state = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t *)pData, ReadAddr, NumOfBlocks);
+        sd_state = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t*)pData, ReadAddr,
+                                         NumOfBlocks);
     }
 
     return (sd_state == HAL_OK) ? MSD_OK : MSD_ERROR;
 }
 
 /**
-  * @brief  Writes block(s) to a specified address in an SD card, in DMA mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
-  * @param  NumOfBlocks: Number of SD blocks to write
-  * @retval SD status
-  */
-uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks)
+ * @brief  Writes block(s) to a specified address in an SD card, in DMA mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  WriteAddr: Address from where data is to be written
+ * @param  NumOfBlocks: Number of SD blocks to write
+ * @retval SD status
+ */
+uint8_t BSP_SD_WriteBlocks_DMA(uint32_t* pData,
+                               uint32_t  WriteAddr,
+                               uint32_t  NumOfBlocks)
 {
     HAL_StatusTypeDef sd_state = HAL_OK;
 
@@ -199,21 +213,22 @@ uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t Num
     /* Prepare the dma channel for a read operation */
     sd_state = SD_DMAConfigTx(&hsd1);
 
-    if (sd_state == HAL_OK)
+    if(sd_state == HAL_OK)
     {
         /* Write block(s) in DMA transfer mode */
-        sd_state = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t *)pData, WriteAddr, NumOfBlocks);
+        sd_state = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t*)pData, WriteAddr,
+                                          NumOfBlocks);
     }
 
     return (sd_state == HAL_OK) ? MSD_OK : MSD_ERROR;
 }
 
 /**
-  * @brief  Erases the specified memory area of the given SD card.
-  * @param  StartAddr: Start byte address
-  * @param  EndAddr: End byte address
-  * @retval SD status
-  */
+ * @brief  Erases the specified memory area of the given SD card.
+ * @param  StartAddr: Start byte address
+ * @param  EndAddr: End byte address
+ * @retval SD status
+ */
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr)
 {
     uint8_t sd_state = MSD_OK;
@@ -227,13 +242,13 @@ uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr)
 }
 
 /**
-  * @brief  Gets the current SD card data status.
-  * @param  None
-  * @retval Data transfer state.
-  *          This value can be one of the following values:
-  *            @arg  SD_TRANSFER_OK: No data transfer is acting
-  *            @arg  SD_TRANSFER_BUSY: Data transfer is acting
-  */
+ * @brief  Gets the current SD card data status.
+ * @param  None
+ * @retval Data transfer state.
+ *          This value can be one of the following values:
+ *            @arg  SD_TRANSFER_OK: No data transfer is acting
+ *            @arg  SD_TRANSFER_BUSY: Data transfer is acting
+ */
 uint8_t BSP_SD_GetCardState(void)
 {
     HAL_SD_CardStateTypedef card_state;
@@ -256,11 +271,11 @@ uint8_t BSP_SD_GetCardState(void)
 }
 
 /**
-  * @brief  Get SD information about specific SD card.
-  * @param  CardInfo: Pointer to HAL_SD_CardInfoTypedef structure
-  * @retval None
-  */
-void BSP_SD_GetCardInfo(BSP_SD_CardInfo *CardInfo)
+ * @brief  Get SD information about specific SD card.
+ * @param  CardInfo: Pointer to HAL_SD_CardInfoTypedef structure
+ * @retval None
+ */
+void BSP_SD_GetCardInfo(BSP_SD_CardInfo* CardInfo)
 {
     HAL_SD_GetCardInfo(&hsd1, CardInfo);
 }
@@ -275,90 +290,87 @@ uint8_t BSP_SD_IsDetected(void)
     return SD_PRESENT;
 }
 
-
 /**
-  * @brief SD Abort callbacks
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_AbortCallback(SD_HandleTypeDef *hsd)
+ * @brief SD Abort callbacks
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_AbortCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_AbortCallback();
 }
 
 /**
-  * @brief SD Error callbacks
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_ErrorCallback(SD_HandleTypeDef *hsd)
+ * @brief SD Error callbacks
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_ErrorCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_ErrorCallback();
 }
 
 /**
-  * @brief Rx Transfer completed callback
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_RxCpltCallback(SD_HandleTypeDef *hsd)
+ * @brief Rx Transfer completed callback
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_RxCpltCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_ReadCpltCallback();
 }
 
 /**
-  * @brief Tx Transfer completed callback
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_TxCpltCallback(SD_HandleTypeDef *hsd)
+ * @brief Tx Transfer completed callback
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_TxCpltCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_WriteCpltCallback();
 }
 
-
 /**
-  * @brief BSP SD Abort callback
-  * @retval None
-  */
+ * @brief BSP SD Abort callback
+ * @retval None
+ */
 __weak void BSP_SD_AbortCallback(void)
 {
     Error_Handler();
 }
 
 /**
-  * @brief BSP SD Error callback
-  * @retval None
-  */
+ * @brief BSP SD Error callback
+ * @retval None
+ */
 __weak void BSP_SD_ErrorCallback(void)
 {
     Error_Handler();
 }
 
 /**
-  * @brief BSP Rx Transfer completed callback
-  * @retval None
-  */
+ * @brief BSP Rx Transfer completed callback
+ * @retval None
+ */
 __weak void BSP_SD_ReadCpltCallback(void)
 {
     // redefined in sd_diskio
 }
 
 /**
-  * @brief BSP Tx Transfer completed callback
-  * @retval None
-  */
+ * @brief BSP Tx Transfer completed callback
+ * @retval None
+ */
 __weak void BSP_SD_WriteCpltCallback(void)
 {
     // redefined in sd_diskio
 }
 
-
 /**
-  * @brief Initializes the SD MSP.
-  * @param None
-  * @retval None
-  */
+ * @brief Initializes the SD MSP.
+ * @param None
+ * @retval None
+ */
 void BSP_SD_MspInit(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -380,7 +392,8 @@ void BSP_SD_MspInit(void)
     GPIO_InitStruct.Alternate = GPIO_AF12_SDMMC1;
 
     /* GPIOC configuration */
-    GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+    GPIO_InitStruct.Pin =
+        GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     /* GPIOD configuration */
@@ -394,14 +407,14 @@ void BSP_SD_MspInit(void)
     /* DMA initialization should be done here but
      * (as there is only one channel for RX and TX)
      * it is configured and done directly when required.
-    */
+     */
 }
 
 /**
-  * @brief De-Initializes the SD MSP.
-  * @param None
-  * @retval None
-  */
+ * @brief De-Initializes the SD MSP.
+ * @param None
+ * @retval None
+ */
 void BSP_SD_MspDeInit(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -422,7 +435,8 @@ void BSP_SD_MspDeInit(void)
     GPIO_InitStruct.Alternate = 0;
 
     /* GPIOC configuration */
-    GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+    GPIO_InitStruct.Pin =
+        GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     /* GPIOD configuration */
@@ -434,14 +448,14 @@ void BSP_SD_MspDeInit(void)
 }
 
 /**
-  * @brief Configure the DMA to receive data from the SD card
-  * @retval
-  *  HAL_ERROR or HAL_OK
-  */
-static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd)
+ * @brief Configure the DMA to receive data from the SD card
+ * @retval
+ *  HAL_ERROR or HAL_OK
+ */
+static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef* hsd)
 {
     static DMA_HandleTypeDef hdma_rx;
-    HAL_StatusTypeDef status = HAL_ERROR;
+    HAL_StatusTypeDef        status = HAL_ERROR;
 
     /* Configure DMA Rx parameters */
     hdma_rx.Instance                 = DMA2_Channel5;
@@ -473,14 +487,14 @@ static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd)
 }
 
 /**
-  * @brief Configure the DMA to transmit data to the SD card
-  * @retval
-  *  HAL_ERROR or HAL_OK
-  */
-static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef *hsd)
+ * @brief Configure the DMA to transmit data to the SD card
+ * @retval
+ *  HAL_ERROR or HAL_OK
+ */
+static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef* hsd)
 {
     static DMA_HandleTypeDef hdma_tx;
-    HAL_StatusTypeDef status;
+    HAL_StatusTypeDef        status;
 
     /* Configure DMA Tx parameters */
     hdma_tx.Instance                 = DMA2_Channel5;

--- a/projects/STM32L496-CustomHw/source/fatfs.c
+++ b/projects/STM32L496-CustomHw/source/fatfs.c
@@ -1,25 +1,25 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   fatfs.c
-  * @brief  FatFS application
-  *         Code for FatFS application
-  *
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   fatfs.c
+ * @brief  FatFS application
+ *         Code for FatFS application
+ *
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "fatfs.h"
 #include "main.h"
 
 /* Variables -----------------------------------------------------------------*/
-char  SDPath[4];        /* SD logical drive path */
-FATFS SDFatFs;          /* File system object for SD logical drive */
-FIL   SDFile;           /* File object for SD */
+char  SDPath[4]; /* SD logical drive path */
+FATFS SDFatFs;   /* File system object for SD logical drive */
+FIL   SDFile;    /* File object for SD */
 
 /* Functions -----------------------------------------------------------------*/
 uint8_t FATFS_Init(void)
@@ -33,10 +33,10 @@ uint8_t FATFS_DeInit(void)
 }
 
 /**
-  * @brief  Gets Time from RTC
-  * @param  None
-  * @retval Time in DWORD
-  */
+ * @brief  Gets Time from RTC
+ * @param  None
+ * @retval Time in DWORD
+ */
 DWORD get_fattime(void)
 {
     return (DWORD)0;

--- a/projects/STM32L496-CustomHw/source/main.c
+++ b/projects/STM32L496-CustomHw/source/main.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   main.c
-  * @brief  Main program
-  *	        This file demonstrates the usage of the bootloader.
-  *
-  * @see    Please refer to README for detailed information.
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   main.c
+ * @brief  Main program
+ *	       This file demonstrates the usage of the bootloader.
+ *
+ * @see    Please refer to README for detailed information.
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "stm32l4xx.h"
 #include "main.h"
@@ -22,9 +22,9 @@
 static uint8_t BTNcounter = 0;
 
 /* External variables --------------------------------------------------------*/
-extern char  SDPath[4];         /* SD logical drive path */
-extern FATFS SDFatFs;           /* File system object for SD logical drive */
-extern FIL   SDFile;            /* File object for SD */
+extern char  SDPath[4]; /* SD logical drive path */
+extern FATFS SDFatFs;   /* File system object for SD logical drive */
+extern FIL   SDFile;    /* File object for SD */
 
 /* Function prototypes -------------------------------------------------------*/
 void    Enter_Bootloader(void);
@@ -53,7 +53,7 @@ int main(void)
     if(__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST))
     {
         print("OBL flag is active.");
-#if (CLEAR_RESET_FLAGS)
+#if(CLEAR_RESET_FLAGS)
         /* Clear system reset flags */
         __HAL_RCC_CLEAR_RESET_FLAGS();
         print("Reset flags cleared.");
@@ -61,20 +61,44 @@ int main(void)
     }
 
     /* Check for user action:
-        - button is pressed >= 1 second:  Enter Bootloader. Green LED is blinking.
-        - button is pressed >= 4 seconds: Enter ST System Memory. Yellow LED is blinking.
+        - button is pressed >= 1 second:  Enter Bootloader. Green LED is
+          blinking.
+        - button is pressed >= 4 seconds: Enter ST System Memory. Yellow LED is
+          blinking.
         - button is pressed >= 9 seconds: Do nothing, launch application.
     */
     while(IS_BTN_PRESSED() && BTNcounter < 90)
     {
-        if(BTNcounter == 10) { print("Release button to enter Bootloader."); }
-        if(BTNcounter == 40) { print("Release button to enter System Memory."); }
+        if(BTNcounter == 10)
+        {
+            print("Release button to enter Bootloader.");
+        }
+        if(BTNcounter == 40)
+        {
+            print("Release button to enter System Memory.");
+        }
 
-        if(BTNcounter < 10)         { LED_ALL_ON(); }
-        else if(BTNcounter == 10)   { LED_ALL_OFF(); }
-        else if(BTNcounter < 40)    { LED_G_TG(); }
-        else if(BTNcounter == 40)   { LED_G_OFF(); LED_Y_ON(); }
-        else                        { LED_Y_TG(); }
+        if(BTNcounter < 10)
+        {
+            LED_ALL_ON();
+        }
+        else if(BTNcounter == 10)
+        {
+            LED_ALL_OFF();
+        }
+        else if(BTNcounter < 40)
+        {
+            LED_G_TG();
+        }
+        else if(BTNcounter == 40)
+        {
+            LED_G_OFF();
+            LED_Y_ON();
+        }
+        else
+        {
+            LED_Y_TG();
+        }
 
         BTNcounter++;
         HAL_Delay(100);
@@ -98,11 +122,10 @@ int main(void)
         }
     }
 
-
     /* Check if there is application in user flash area */
     if(Bootloader_CheckForApplication() == BL_OK)
     {
-#if (USE_CHECKSUM)
+#if(USE_CHECKSUM)
         /* Verify application checksum */
         if(Bootloader_VerifyChecksum() != BL_OK)
         {
@@ -132,10 +155,14 @@ int main(void)
     print("No application in flash.");
     while(1)
     {
-        LED_R_ON();     HAL_Delay(150);
-        LED_R_OFF();    HAL_Delay(150);
-        LED_R_ON();     HAL_Delay(150);
-        LED_R_OFF();    HAL_Delay(1050);
+        LED_R_ON();
+        HAL_Delay(150);
+        LED_R_OFF();
+        HAL_Delay(150);
+        LED_R_ON();
+        HAL_Delay(150);
+        LED_R_OFF();
+        HAL_Delay(1050);
     }
 }
 
@@ -157,13 +184,14 @@ void Enter_Bootloader(void)
         print("Application space in flash is write protected.");
         print("Press button to disable flash write protection...");
         LED_R_ON();
-        for(i=0; i<100; ++i)
+        for(i = 0; i < 100; ++i)
         {
             LED_Y_TG();
             HAL_Delay(50);
             if(IS_BTN_PRESSED())
             {
-                print("Disabling write protection and generating system reset...");
+                print("Disabling write protection and generating system "
+                      "reset...");
                 Bootloader_ConfigProtection(BL_PROTECTION_NONE);
             }
         }
@@ -210,7 +238,7 @@ void Enter_Bootloader(void)
     print("Software found on SD.");
 
     /* Check size of application found on SD card */
-    if(Bootloader_CheckSize( f_size(&SDFile) ) != BL_OK)
+    if(Bootloader_CheckSize(f_size(&SDFile)) != BL_OK)
     {
         print("Error: app on SD card is too large.");
 
@@ -250,7 +278,7 @@ void Enter_Bootloader(void)
     do
     {
         data = 0xFFFFFFFFFFFFFFFF;
-        fr = f_read(&SDFile, &data, 8, &num);
+        fr   = f_read(&SDFile, &data, 8, &num);
         if(num)
         {
             status = Bootloader_FlashNext(data);
@@ -260,7 +288,7 @@ void Enter_Bootloader(void)
             }
             else
             {
-                sprintf(msg, "Programming error at: %lu byte", (cntr*8));
+                sprintf(msg, "Programming error at: %lu byte", (cntr * 8));
                 print(msg);
 
                 f_close(&SDFile);
@@ -285,7 +313,7 @@ void Enter_Bootloader(void)
     LED_G_OFF();
     LED_Y_OFF();
     print("Programming finished.");
-    sprintf(msg, "Flashed: %lu bytes.", (cntr*8));
+    sprintf(msg, "Flashed: %lu bytes.", (cntr * 8));
     print(msg);
 
     /* Open file for verification */
@@ -308,7 +336,7 @@ void Enter_Bootloader(void)
     do
     {
         data = 0xFFFFFFFFFFFFFFFF;
-        fr = f_read(&SDFile, &data, 4, &num);
+        fr   = f_read(&SDFile, &data, 4, &num);
         if(num)
         {
             if(*(uint32_t*)addr == (uint32_t)data)
@@ -318,7 +346,7 @@ void Enter_Bootloader(void)
             }
             else
             {
-                sprintf(msg, "Verification error at: %lu byte.", (cntr*4));
+                sprintf(msg, "Verification error at: %lu byte.", (cntr * 4));
                 print(msg);
 
                 f_close(&SDFile);
@@ -343,7 +371,7 @@ void Enter_Bootloader(void)
     print("SD ejected.");
 
     /* Enable flash write protection */
-#if (USE_WRITE_PROTECTION)
+#if(USE_WRITE_PROTECTION)
     print("Enablig flash write protection and generating system reset...");
     if(Bootloader_ConfigProtection(BL_PROTECTION_WRP) != BL_OK)
     {
@@ -400,8 +428,8 @@ void GPIO_Init(void)
     HAL_GPIO_WritePin(SD_PWR_Port, SD_PWR_Pin, GPIO_PIN_SET);
 
     /* LED_G_Pin, LED_Y_Pin, LED_R_Pin */
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull  = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 
     GPIO_InitStruct.Pin = LED_G_Pin;
@@ -414,16 +442,16 @@ void GPIO_Init(void)
     HAL_GPIO_Init(LED_R_Port, &GPIO_InitStruct);
 
     /* SD Card Power Pin */
-    GPIO_InitStruct.Pin = SD_PWR_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Pin   = SD_PWR_Pin;
+    GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull  = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(SD_PWR_Port, &GPIO_InitStruct);
 
     /* User Button */
-    GPIO_InitStruct.Pin = BTN_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    GPIO_InitStruct.Pin   = BTN_Pin;
+    GPIO_InitStruct.Mode  = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull  = GPIO_PULLUP;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(BTN_Port, &GPIO_InitStruct);
 }
@@ -442,30 +470,31 @@ void GPIO_DeInit(void)
 /*** System Clock Configuration ***/
 void SystemClock_Config(void)
 {
-    RCC_OscInitTypeDef RCC_OscInitStruct;
-    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+    RCC_OscInitTypeDef       RCC_OscInitStruct;
+    RCC_ClkInitTypeDef       RCC_ClkInitStruct;
     RCC_PeriphCLKInitTypeDef PeriphClkInit;
 
     /* Initializes the CPU, AHB and APB bus clocks */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
-    RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+    RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI;
+    RCC_OscInitStruct.MSIState            = RCC_MSI_ON;
     RCC_OscInitStruct.MSICalibrationValue = 0;
-    RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
-    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
-    RCC_OscInitStruct.PLL.PLLM = 1;
-    RCC_OscInitStruct.PLL.PLLN = 24;
-    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
-    RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
-    RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+    RCC_OscInitStruct.MSIClockRange       = RCC_MSIRANGE_6;
+    RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_MSI;
+    RCC_OscInitStruct.PLL.PLLM            = 1;
+    RCC_OscInitStruct.PLL.PLLN            = 24;
+    RCC_OscInitStruct.PLL.PLLP            = RCC_PLLP_DIV2;
+    RCC_OscInitStruct.PLL.PLLQ            = RCC_PLLQ_DIV2;
+    RCC_OscInitStruct.PLL.PLLR            = RCC_PLLR_DIV2;
     if(HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
     {
         Error_Handler();
     }
 
-    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
-    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                                  RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
@@ -474,14 +503,14 @@ void SystemClock_Config(void)
         Error_Handler();
     }
 
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_SDMMC1;
-    PeriphClkInit.Sdmmc1ClockSelection = RCC_SDMMC1CLKSOURCE_PLLSAI1;
-    PeriphClkInit.PLLSAI1.PLLSAI1Source = RCC_PLLSOURCE_MSI;
-    PeriphClkInit.PLLSAI1.PLLSAI1M = 1;
-    PeriphClkInit.PLLSAI1.PLLSAI1N = 24;
-    PeriphClkInit.PLLSAI1.PLLSAI1P = RCC_PLLP_DIV2;
-    PeriphClkInit.PLLSAI1.PLLSAI1Q = RCC_PLLQ_DIV2;
-    PeriphClkInit.PLLSAI1.PLLSAI1R = RCC_PLLR_DIV2;
+    PeriphClkInit.PeriphClockSelection    = RCC_PERIPHCLK_SDMMC1;
+    PeriphClkInit.Sdmmc1ClockSelection    = RCC_SDMMC1CLKSOURCE_PLLSAI1;
+    PeriphClkInit.PLLSAI1.PLLSAI1Source   = RCC_PLLSOURCE_MSI;
+    PeriphClkInit.PLLSAI1.PLLSAI1M        = 1;
+    PeriphClkInit.PLLSAI1.PLLSAI1N        = 24;
+    PeriphClkInit.PLLSAI1.PLLSAI1P        = RCC_PLLP_DIV2;
+    PeriphClkInit.PLLSAI1.PLLSAI1Q        = RCC_PLLQ_DIV2;
+    PeriphClkInit.PLLSAI1.PLLSAI1R        = RCC_PLLR_DIV2;
     PeriphClkInit.PLLSAI1.PLLSAI1ClockOut = RCC_PLLSAI1_48M2CLK;
     if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
     {
@@ -495,7 +524,7 @@ void SystemClock_Config(void)
     }
 
     /* Configure the Systick */
-    HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/1000);
+    HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq() / 1000);
     HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_HCLK);
     HAL_NVIC_SetPriority(SysTick_IRQn, 0, 0);
 }
@@ -520,16 +549,16 @@ void HAL_MspInit(void)
 /*** Debug ***/
 void print(const char* str)
 {
-#if (USE_SWO_TRACE)
+#if(USE_SWO_TRACE)
     puts(str);
 #endif
 }
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @param  None
-  * @retval None
-  */
+ * @brief  This function is executed in case of error occurrence.
+ * @param  None
+ * @retval None
+ */
 void Error_Handler(void)
 {
     while(1)
@@ -542,15 +571,14 @@ void Error_Handler(void)
 #ifdef USE_FULL_ASSERT
 
 /**
-   * @brief Reports the name of the source file and the source line number
-   * where the assert_param error has occurred.
-   * @param file: pointer to the source file name
-   * @param line: assert_param error line source number
-   * @retval None
-   */
+ * @brief Reports the name of the source file and the source line number
+ * where the assert_param error has occurred.
+ * @param file: pointer to the source file name
+ * @param line: assert_param error line source number
+ * @retval None
+ */
 void assert_failed(uint8_t* file, uint32_t line)
 {
-
 }
 
 #endif

--- a/projects/STM32L496-CustomHw/source/sd_diskio.c
+++ b/projects/STM32L496-CustomHw/source/sd_diskio.c
@@ -1,23 +1,23 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   sd_diskio.c
-  * @brief  SD diskio driver
-  *	        This file contains the implementation of the SD diskio driver
-  *         used by the FatFs module. The driver uses the HAL library of ST.
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   sd_diskio.c
+ * @brief  SD diskio driver
+ *	       This file contains the implementation of the SD diskio driver
+ *         used by the FatFs module. The driver uses the HAL library of ST.
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "ff_gen_drv.h"
 #include "sd_diskio.h"
 
 /* Defines -------------------------------------------------------------------*/
-#define SD_TIMEOUT      SD_DATATIMEOUT      /* Defined in bsp_driver_sd.h */
+#define SD_TIMEOUT SD_DATATIMEOUT /* Defined in bsp_driver_sd.h */
 
 /*
  * Depending on the use case, the SD card initialization could be done at the
@@ -42,38 +42,33 @@
 //#define ENABLE_SD_DMA_CACHE_MAINTENANCE 1
 
 /* Private variables ---------------------------------------------------------*/
-static volatile DSTATUS Stat = STA_NOINIT;      /* Disk status */
-static volatile UINT    ReadStatus = 0;
+static volatile DSTATUS Stat        = STA_NOINIT; /* Disk status */
+static volatile UINT    ReadStatus  = 0;
 static volatile UINT    WriteStatus = 0;
 
 /* Private function prototypes -----------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun);
-DSTATUS SD_initialize (BYTE);
-DSTATUS SD_status (BYTE);
-DRESULT SD_read (BYTE, BYTE*, DWORD, UINT);
+DSTATUS        SD_initialize(BYTE);
+DSTATUS        SD_status(BYTE);
+DRESULT        SD_read(BYTE, BYTE*, DWORD, UINT);
 
 #if _USE_WRITE == 1
-DRESULT SD_write (BYTE, const BYTE*, DWORD, UINT);
+DRESULT SD_write(BYTE, const BYTE*, DWORD, UINT);
 #endif /* _USE_WRITE == 1 */
 
 #if _USE_IOCTL == 1
-DRESULT SD_ioctl (BYTE, BYTE, void*);
-#endif  /* _USE_IOCTL == 1 */
+DRESULT SD_ioctl(BYTE, BYTE, void*);
+#endif /* _USE_IOCTL == 1 */
 
-
-const Diskio_drvTypeDef  SD_Driver =
-{
-    SD_initialize,
-    SD_status,
-    SD_read,
-#if  _USE_WRITE == 1
+const Diskio_drvTypeDef SD_Driver = {
+    SD_initialize, SD_status, SD_read,
+#if _USE_WRITE == 1
     SD_write,
 #endif /* _USE_WRITE == 1 */
-#if  _USE_IOCTL == 1
+#if _USE_IOCTL == 1
     SD_ioctl,
 #endif /* _USE_IOCTL == 1 */
 };
-
 
 /* Private functions ---------------------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun)
@@ -89,10 +84,10 @@ static DSTATUS SD_CheckStatus(BYTE lun)
 }
 
 /**
-  * @brief  Initializes a Drive
-  * @param  lun : not used
-  * @retval DSTATUS: Operation status
-  */
+ * @brief  Initializes a Drive
+ * @param  lun : not used
+ * @retval DSTATUS: Operation status
+ */
 DSTATUS SD_initialize(BYTE lun)
 {
     Stat = STA_NOINIT;
@@ -106,31 +101,31 @@ DSTATUS SD_initialize(BYTE lun)
     Stat = SD_CheckStatus(lun);
 #endif
 
-    ReadStatus = 0;
+    ReadStatus  = 0;
     WriteStatus = 0;
 
     return Stat;
 }
 
 /**
-  * @brief  Gets Disk Status
-  * @param  lun : not used
-  * @retval DSTATUS: Operation status
-  */
+ * @brief  Gets Disk Status
+ * @param  lun : not used
+ * @retval DSTATUS: Operation status
+ */
 DSTATUS SD_status(BYTE lun)
 {
     return SD_CheckStatus(lun);
 }
 
 /**
-  * @brief  Reads Sector(s)
-  * @param  lun : not used
-  * @param  *buff: Data buffer to store read data
-  * @param  sector: Sector address (LBA)
-  * @param  count: Number of sectors to read (1..128)
-  * @retval DRESULT: Operation result
-  */
-DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
+ * @brief  Reads Sector(s)
+ * @param  lun : not used
+ * @param  *buff: Data buffer to store read data
+ * @param  sector: Sector address (LBA)
+ * @param  count: Number of sectors to read (1..128)
+ * @retval DRESULT: Operation result
+ */
+DRESULT SD_read(BYTE lun, BYTE* buff, DWORD sector, UINT count)
 {
     DRESULT  res;
     uint32_t timeout;
@@ -142,10 +137,11 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
     uint32_t alignedAddr;
 #endif /* SD_DMA_CACHE_MAINTENANCE */
 
-    res = RES_ERROR;
+    res        = RES_ERROR;
     ReadStatus = 0;
 
-    if(BSP_SD_ReadBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) == MSD_OK)
+    if(BSP_SD_ReadBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) ==
+       MSD_OK)
     {
         /* Wait for DMA Complete */
         timeout = HAL_GetTick();
@@ -161,18 +157,21 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
         else
         {
             ReadStatus = 0;
-            timeout = HAL_GetTick();
+            timeout    = HAL_GetTick();
             while((HAL_GetTick() - timeout) < SD_TIMEOUT)
             {
                 if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
                 {
                     res = RES_OK;
 #if defined(ENABLE_SD_DMA_CACHE_MAINTENANCE)
-                    /* The SCB_InvalidateDCache_by_Addr() requires a 32-Byte aligned address,
-                     * adjust the address and the D-Cache size to invalidate accordingly.
-                    */
+                    /* The SCB_InvalidateDCache_by_Addr() requires a 32-Byte
+                     * aligned address, adjust the address and the D-Cache size
+                     * to invalidate accordingly.
+                     */
                     alignedAddr = (uint32_t)buff & ~0x1F;
-                    SCB_InvalidateDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+                    SCB_InvalidateDCache_by_Addr(
+                        (uint32_t*)alignedAddr,
+                        count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif /* SD_DMA_CACHE_MAINTENANCE */
                     break;
                 }
@@ -185,9 +184,8 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 #else
     /* Use SD Driver in blocking mode */
     res = RES_ERROR;
-    if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                         (uint32_t)(sector),
-                         count, SDMMC_HAL_TIMEOUT) == MSD_OK)
+    if(BSP_SD_ReadBlocks((uint32_t*)buff, (uint32_t)(sector), count,
+                         SDMMC_HAL_TIMEOUT) == MSD_OK)
     {
         /* Wait until the read operation is finished */
         timeout = HAL_GetTick();
@@ -204,17 +202,16 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 #endif /* ENABLE_SD_DMA_DRIVER */
 }
 
-
 /**
-  * @brief  Writes Sector(s)
-  * @param  lun : not used
-  * @param  *buff: Data to be written
-  * @param  sector: Sector address (LBA)
-  * @param  count: Number of sectors to write (1..128)
-  * @retval DRESULT: Operation result
-  */
+ * @brief  Writes Sector(s)
+ * @param  lun : not used
+ * @param  *buff: Data to be written
+ * @param  sector: Sector address (LBA)
+ * @param  count: Number of sectors to write (1..128)
+ * @retval DRESULT: Operation result
+ */
 #if _USE_WRITE == 1
-DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
+DRESULT SD_write(BYTE lun, const BYTE* buff, DWORD sector, UINT count)
 {
     DRESULT  res;
     uint32_t timeout;
@@ -224,14 +221,16 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 
 #if defined(ENABLE_SD_DMA_CACHE_MAINTENANCE)
     uint32_t alignedAddr;
-    alignedAddr = (uint32_t)buff &  ~0x1F;
-    SCB_CleanDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+    alignedAddr = (uint32_t)buff & ~0x1F;
+    SCB_CleanDCache_by_Addr((uint32_t*)alignedAddr,
+                            count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif
 
-    res = RES_ERROR;
+    res         = RES_ERROR;
     WriteStatus = 0;
 
-    if(BSP_SD_WriteBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) == MSD_OK)
+    if(BSP_SD_WriteBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) ==
+       MSD_OK)
     {
         /* Wait for DMA complete */
         timeout = HAL_GetTick();
@@ -247,7 +246,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
         else
         {
             WriteStatus = 0;
-            timeout = HAL_GetTick();
+            timeout     = HAL_GetTick();
             while((HAL_GetTick() - timeout) < SD_TIMEOUT)
             {
                 if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
@@ -264,9 +263,8 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 #else
     /* Use SD Driver in blocking mode */
     res = RES_ERROR;
-    if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                          (uint32_t)(sector),
-                          count, SDMMC_HAL_TIMEOUT) == MSD_OK)
+    if(BSP_SD_WriteBlocks((uint32_t*)buff, (uint32_t)(sector), count,
+                          SDMMC_HAL_TIMEOUT) == MSD_OK)
     {
         /* Wait until the Write operation is finished */
         timeout = HAL_GetTick();
@@ -285,75 +283,74 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 #endif /* _USE_WRITE == 1 */
 
 /**
-  * @brief  I/O control operation
-  * @param  lun : not used
-  * @param  cmd: Control code
-  * @param  *buff: Buffer to send/receive control data
-  * @retval DRESULT: Operation result
-  */
+ * @brief  I/O control operation
+ * @param  lun : not used
+ * @param  cmd: Control code
+ * @param  *buff: Buffer to send/receive control data
+ * @retval DRESULT: Operation result
+ */
 #if _USE_IOCTL == 1
-DRESULT SD_ioctl(BYTE lun, BYTE cmd, void *buff)
+DRESULT SD_ioctl(BYTE lun, BYTE cmd, void* buff)
 {
-  DRESULT res = RES_ERROR;
-  BSP_SD_CardInfo CardInfo;
+    DRESULT         res = RES_ERROR;
+    BSP_SD_CardInfo CardInfo;
 
-  if(Stat & STA_NOINIT)
-  {
-      return RES_NOTRDY;
-  }
+    if(Stat & STA_NOINIT)
+    {
+        return RES_NOTRDY;
+    }
 
-  switch(cmd)
-  {
-      /* Make sure that no pending write process */
-      case CTRL_SYNC :
-        res = RES_OK;
-        break;
+    switch(cmd)
+    {
+        /* Make sure that no pending write process */
+        case CTRL_SYNC:
+            res = RES_OK;
+            break;
 
-      /* Get number of sectors on the disk (DWORD) */
-      case GET_SECTOR_COUNT :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(DWORD*)buff = CardInfo.LogBlockNbr;
-        res = RES_OK;
-        break;
+        /* Get number of sectors on the disk (DWORD) */
+        case GET_SECTOR_COUNT:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(DWORD*)buff = CardInfo.LogBlockNbr;
+            res           = RES_OK;
+            break;
 
-      /* Get R/W sector size (WORD) */
-      case GET_SECTOR_SIZE :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(WORD*)buff = CardInfo.LogBlockSize;
-        res = RES_OK;
-        break;
+        /* Get R/W sector size (WORD) */
+        case GET_SECTOR_SIZE:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(WORD*)buff = CardInfo.LogBlockSize;
+            res          = RES_OK;
+            break;
 
-      /* Get erase block size in unit of sector (DWORD) */
-      case GET_BLOCK_SIZE :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(DWORD*)buff = CardInfo.LogBlockSize;
-        res = RES_OK;
-        break;
+        /* Get erase block size in unit of sector (DWORD) */
+        case GET_BLOCK_SIZE:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(DWORD*)buff = CardInfo.LogBlockSize;
+            res           = RES_OK;
+            break;
 
-      default:
-        res = RES_PARERR;
-  }
+        default:
+            res = RES_PARERR;
+    }
 
-  return res;
+    return res;
 }
 #endif /* _USE_IOCTL == 1 */
 
-
 /**
-  * @brief Rx Transfer complete callback
-  * @param hsd: SD handle
-  * @retval None
-  */
+ * @brief Rx Transfer complete callback
+ * @param hsd: SD handle
+ * @retval None
+ */
 void BSP_SD_ReadCpltCallback(void)
 {
     ReadStatus = 1;
 }
 
 /**
-  * @brief Tx Transfer complete callback
-  * @param hsd: SD handle
-  * @retval None
-  */
+ * @brief Tx Transfer complete callback
+ * @param hsd: SD handle
+ * @retval None
+ */
 void BSP_SD_WriteCpltCallback(void)
 {
     WriteStatus = 1;

--- a/projects/STM32L496-CustomHw/source/stm32l4xx_it.c
+++ b/projects/STM32L496-CustomHw/source/stm32l4xx_it.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   stm32l4xx_it.c
-  * @brief  Interrupt Service Routines
-  *	        This file contains the exception and peripheral interrupt handlers.
-  *
-  *
-  ******************************************************************************
-  * Copyright (c) 2018 Akos Pasztor.                    https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   stm32l4xx_it.c
+ * @brief  Interrupt Service Routines
+ *	       This file contains the exception and peripheral interrupt handlers.
+ *
+ *
+ *******************************************************************************
+ * Copyright (c) 2020 Akos Pasztor.                     https://akospasztor.com
+ *******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32l4xx_hal.h"
@@ -25,16 +25,15 @@ extern SD_HandleTypeDef hsd1;
 /******************************************************************************/
 
 /**
-* @brief This function handles Non maskable interrupt.
-*/
+ * @brief This function handles Non maskable interrupt.
+ */
 void NMI_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Hard fault interrupt.
-*/
+ * @brief This function handles Hard fault interrupt.
+ */
 void HardFault_Handler(void)
 {
     while(1)
@@ -43,8 +42,8 @@ void HardFault_Handler(void)
 }
 
 /**
-* @brief This function handles Memory management fault.
-*/
+ * @brief This function handles Memory management fault.
+ */
 void MemManage_Handler(void)
 {
     while(1)
@@ -53,8 +52,8 @@ void MemManage_Handler(void)
 }
 
 /**
-* @brief This function handles Prefetch fault, memory access fault.
-*/
+ * @brief This function handles Prefetch fault, memory access fault.
+ */
 void BusFault_Handler(void)
 {
     while(1)
@@ -63,8 +62,8 @@ void BusFault_Handler(void)
 }
 
 /**
-* @brief This function handles Undefined instruction or illegal state.
-*/
+ * @brief This function handles Undefined instruction or illegal state.
+ */
 void UsageFault_Handler(void)
 {
     while(1)
@@ -73,32 +72,29 @@ void UsageFault_Handler(void)
 }
 
 /**
-* @brief This function handles System service call via SWI instruction.
-*/
+ * @brief This function handles System service call via SWI instruction.
+ */
 void SVC_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Debug monitor.
-*/
+ * @brief This function handles Debug monitor.
+ */
 void DebugMon_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Pendable request for system service.
-*/
+ * @brief This function handles Pendable request for system service.
+ */
 void PendSV_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles System tick timer.
-*/
+ * @brief This function handles System tick timer.
+ */
 void SysTick_Handler(void)
 {
     HAL_IncTick();
@@ -110,9 +106,9 @@ void SysTick_Handler(void)
 /******************************************************************************/
 
 /**
-* @brief DMA2 Channel5 ISR
-* @note  SDMMC DMA Tx, Rx
-*/
+ * @brief DMA2 Channel5 ISR
+ * @note  SDMMC DMA Tx, Rx
+ */
 void DMA2_Channel5_IRQHandler(void)
 {
     if((hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_READ_SINGLE_BLOCK)) ||
@@ -120,16 +116,18 @@ void DMA2_Channel5_IRQHandler(void)
     {
         HAL_DMA_IRQHandler(hsd1.hdmarx);
     }
-    else if((hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_SINGLE_BLOCK)) ||
-            (hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_MULTIPLE_BLOCK)))
+    else if((hsd1.Context ==
+             (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_SINGLE_BLOCK)) ||
+            (hsd1.Context ==
+             (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_MULTIPLE_BLOCK)))
     {
         HAL_DMA_IRQHandler(hsd1.hdmatx);
     }
 }
 
 /**
-* @brief SDMMC ISR
-*/
+ * @brief SDMMC ISR
+ */
 void SDMMC1_IRQHandler(void)
 {
     HAL_SD_IRQHandler(&hsd1);

--- a/projects/STM32L496-CustomHw/source/system_stm32l4xx.c
+++ b/projects/STM32L496-CustomHw/source/system_stm32l4xx.c
@@ -1,353 +1,369 @@
 /**
-  ******************************************************************************
-  * @file    system_stm32l4xx.c
-  * @author  MCD Application Team
-  * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
-  *
-  *   This file provides two functions and one global variable to be called from
-  *   user application:
-  *      - SystemInit(): This function is called at startup just after reset and
-  *                      before branch to main program. This call is made inside
-  *                      the "startup_stm32l4xx.s" file.
-  *
-  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
-  *                                  by the user application to setup the SysTick
-  *                                  timer or configure other parameters.
-  *
-  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
-  *                                 be called whenever the core clock is changed
-  *                                 during program execution.
-  *
-  *   After each device reset the MSI (4 MHz) is used as system clock source.
-  *   Then SystemInit() function is called, in "startup_stm32l4xx.s" file, to
-  *   configure the system clock before to branch to main program.
-  *
-  *   This file configures the system clock as follows:
-  *=============================================================================
-  *-----------------------------------------------------------------------------
-  *        System Clock source                    | MSI
-  *-----------------------------------------------------------------------------
-  *        SYSCLK(Hz)                             | 4000000
-  *-----------------------------------------------------------------------------
-  *        HCLK(Hz)                               | 4000000
-  *-----------------------------------------------------------------------------
-  *        AHB Prescaler                          | 1
-  *-----------------------------------------------------------------------------
-  *        APB1 Prescaler                         | 1
-  *-----------------------------------------------------------------------------
-  *        APB2 Prescaler                         | 1
-  *-----------------------------------------------------------------------------
-  *        PLL_M                                  | 1
-  *-----------------------------------------------------------------------------
-  *        PLL_N                                  | 8
-  *-----------------------------------------------------------------------------
-  *        PLL_P                                  | 7
-  *-----------------------------------------------------------------------------
-  *        PLL_Q                                  | 2
-  *-----------------------------------------------------------------------------
-  *        PLL_R                                  | 2
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_P                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_Q                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_R                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_P                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_Q                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_R                              | NA
-  *-----------------------------------------------------------------------------
-  *        Require 48MHz for USB OTG FS,          | Disabled
-  *        SDIO and RNG clock                     |
-  *-----------------------------------------------------------------------------
-  *=============================================================================
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+ *******************************************************************************
+ * @file    system_stm32l4xx.c
+ * @author  MCD Application Team
+ * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
+ *
+ *   This file provides two functions and one global variable to be called from
+ *   user application:
+ *      - SystemInit(): This function is called at startup just after reset and
+ *                      before branch to main program. This call is made inside
+ *                      the "startup_stm32l4xx.s" file.
+ *
+ *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be
+ *used by the user application to setup the SysTick timer or configure other
+ *parameters.
+ *
+ *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+ *                                 be called whenever the core clock is changed
+ *                                 during program execution.
+ *
+ *   After each device reset the MSI (4 MHz) is used as system clock source.
+ *   Then SystemInit() function is called, in "startup_stm32l4xx.s" file, to
+ *   configure the system clock before to branch to main program.
+ *
+ *   This file configures the system clock as follows:
+ *==============================================================================
+ *------------------------------------------------------------------------------
+ *        System Clock source                    | MSI
+ *------------------------------------------------------------------------------
+ *        SYSCLK(Hz)                             | 4000000
+ *------------------------------------------------------------------------------
+ *        HCLK(Hz)                               | 4000000
+ *------------------------------------------------------------------------------
+ *        AHB Prescaler                          | 1
+ *------------------------------------------------------------------------------
+ *        APB1 Prescaler                         | 1
+ *------------------------------------------------------------------------------
+ *        APB2 Prescaler                         | 1
+ *------------------------------------------------------------------------------
+ *        PLL_M                                  | 1
+ *------------------------------------------------------------------------------
+ *        PLL_N                                  | 8
+ *------------------------------------------------------------------------------
+ *        PLL_P                                  | 7
+ *------------------------------------------------------------------------------
+ *        PLL_Q                                  | 2
+ *------------------------------------------------------------------------------
+ *        PLL_R                                  | 2
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_P                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_Q                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_R                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_P                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_Q                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_R                              | NA
+ *------------------------------------------------------------------------------
+ *        Require 48MHz for USB OTG FS,          | Disabled
+ *        SDIO and RNG clock                     |
+ *------------------------------------------------------------------------------
+ *==============================================================================
+ *******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *notice, this list of conditions and the following disclaimer in the
+ *documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ *******************************************************************************
+ */
 
 /** @addtogroup CMSIS
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup stm32l4xx_system
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Includes
-  * @{
-  */
+ * @{
+ */
 
 #include "stm32l4xx.h"
 
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    8000000U  /*!< Value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+#if !defined(HSE_VALUE)
+#define HSE_VALUE 8000000U /*!< Value of the External oscillator in Hz */
+#endif                     /* HSE_VALUE */
 
-#if !defined  (MSI_VALUE)
-  #define MSI_VALUE    4000000U  /*!< Value of the Internal oscillator in Hz*/
-#endif /* MSI_VALUE */
+#if !defined(MSI_VALUE)
+#define MSI_VALUE 4000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                     /* MSI_VALUE */
 
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    16000000U /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
+#if !defined(HSI_VALUE)
+#define HSI_VALUE 16000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                      /* HSI_VALUE */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_TypesDefinitions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Defines
-  * @{
-  */
+ * @{
+ */
 
 /************************* Miscellaneous Configuration ************************/
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
-                                   This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET                       \
+    0x00 /*!< Vector Table base offset field. \
+              This value must be a multiple of 0x200. */
 /******************************************************************************/
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Macros
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Variables
-  * @{
-  */
-  /* The SystemCoreClock variable is updated in three ways:
-      1) by calling CMSIS function SystemCoreClockUpdate()
-      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
-      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
-         Note: If you use this function to configure the system clock; then there
-               is no need to call the 2 first functions listed above, since SystemCoreClock
-               variable is updated automatically.
-  */
-  uint32_t SystemCoreClock = 4000000U;
+ * @{
+ */
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock
+   frequency Note: If you use this function to configure the system clock; then
+   there is no need to call the 2 first functions listed above, since
+   SystemCoreClock variable is updated automatically.
+*/
+uint32_t SystemCoreClock = 4000000U;
 
-  const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
-  const uint8_t  APBPrescTable[8] =  {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
-  const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,  1000000U,  2000000U, \
-                                      4000000U, 8000000U, 16000000U, 24000000U, 32000000U, 48000000U};
+const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
+                                   1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
+const uint8_t  APBPrescTable[8]  = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
+const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,
+                                    1000000U,  2000000U,  4000000U,  8000000U,
+                                    16000000U, 24000000U, 32000000U, 48000000U};
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_FunctionPrototypes
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Functions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @brief  Setup the microcontroller system.
-  * @param  None
-  * @retval None
-  */
+ * @brief  Setup the microcontroller system.
+ * @param  None
+ * @retval None
+ */
 
 void SystemInit(void)
 {
-  /* FPU settings ------------------------------------------------------------*/
-  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
-  #endif
+/* FPU settings ------------------------------------------------------------*/
+#if(__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |=
+        ((3UL << 10 * 2) | (3UL << 11 * 2)); /* set CP10 and CP11 Full Access */
+#endif
 
-  /* Reset the RCC clock configuration to the default reset state ------------*/
-  /* Set MSION bit */
-  RCC->CR |= RCC_CR_MSION;
+    /* Reset the RCC clock configuration to the default reset state
+     * ------------*/
+    /* Set MSION bit */
+    RCC->CR |= RCC_CR_MSION;
 
-  /* Reset CFGR register */
-  RCC->CFGR = 0x00000000U;
+    /* Reset CFGR register */
+    RCC->CFGR = 0x00000000U;
 
-  /* Reset HSEON, CSSON , HSION, and PLLON bits */
-  RCC->CR &= 0xEAF6FFFFU;
+    /* Reset HSEON, CSSON , HSION, and PLLON bits */
+    RCC->CR &= 0xEAF6FFFFU;
 
-  /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x00001000U;
+    /* Reset PLLCFGR register */
+    RCC->PLLCFGR = 0x00001000U;
 
-  /* Reset HSEBYP bit */
-  RCC->CR &= 0xFFFBFFFFU;
+    /* Reset HSEBYP bit */
+    RCC->CR &= 0xFFFBFFFFU;
 
-  /* Disable all interrupts */
-  RCC->CIER = 0x00000000U;
+    /* Disable all interrupts */
+    RCC->CIER = 0x00000000U;
 
-  /* Configure the Vector Table location add offset address ------------------*/
+    /* Configure the Vector Table location add offset address
+     * ------------------*/
 #ifdef VECT_TAB_SRAM
-  SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+    SCB->VTOR = SRAM_BASE |
+                VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = FLASH_BASE |
+                VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 }
 
 /**
-  * @brief  Update SystemCoreClock variable according to Clock Register Values.
-  *         The SystemCoreClock variable contains the core clock (HCLK), it can
-  *         be used by the user application to setup the SysTick timer or configure
-  *         other parameters.
-  *
-  * @note   Each time the core clock (HCLK) changes, this function must be called
-  *         to update SystemCoreClock variable value. Otherwise, any configuration
-  *         based on this variable will be incorrect.
-  *
-  * @note   - The system frequency computed by this function is not the real
-  *           frequency in the chip. It is calculated based on the predefined
-  *           constant and the selected clock source:
-  *
-  *           - If SYSCLK source is MSI, SystemCoreClock will contain the MSI_VALUE(*)
-  *
-  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(**)
-  *
-  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(***)
-  *
-  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(***)
-  *             or HSI_VALUE(*) or MSI_VALUE(*) multiplied/divided by the PLL factors.
-  *
-  *         (*) MSI_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *             4 MHz) but the real value may vary depending on the variations
-  *             in voltage and temperature.
-  *
-  *         (**) HSI_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *              16 MHz) but the real value may vary depending on the variations
-  *              in voltage and temperature.
-  *
-  *         (***) HSE_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *              8 MHz), user has to ensure that HSE_VALUE is same as the real
-  *              frequency of the crystal used. Otherwise, this function may
-  *              have wrong result.
-  *
-  *         - The result of this function could be not correct when using fractional
-  *           value for HSE crystal.
-  *
-  * @param  None
-  * @retval None
-  */
+ * @brief  Update SystemCoreClock variable according to Clock Register Values.
+ *         The SystemCoreClock variable contains the core clock (HCLK), it can
+ *         be used by the user application to setup the SysTick timer or
+ * configure other parameters.
+ *
+ * @note   Each time the core clock (HCLK) changes, this function must be called
+ *         to update SystemCoreClock variable value. Otherwise, any
+ * configuration based on this variable will be incorrect.
+ *
+ * @note   - The system frequency computed by this function is not the real
+ *           frequency in the chip. It is calculated based on the predefined
+ *           constant and the selected clock source:
+ *
+ *           - If SYSCLK source is MSI, SystemCoreClock will contain the
+ * MSI_VALUE(*)
+ *
+ *           - If SYSCLK source is HSI, SystemCoreClock will contain the
+ * HSI_VALUE(**)
+ *
+ *           - If SYSCLK source is HSE, SystemCoreClock will contain the
+ * HSE_VALUE(***)
+ *
+ *           - If SYSCLK source is PLL, SystemCoreClock will contain the
+ * HSE_VALUE(***) or HSI_VALUE(*) or MSI_VALUE(*) multiplied/divided by the PLL
+ * factors.
+ *
+ *         (*) MSI_VALUE is a constant defined in stm32l4xx_hal.h file (default
+ * value 4 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (**) HSI_VALUE is a constant defined in stm32l4xx_hal.h file (default
+ * value 16 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (***) HSE_VALUE is a constant defined in stm32l4xx_hal.h file
+ * (default value 8 MHz), user has to ensure that HSE_VALUE is same as the real
+ *              frequency of the crystal used. Otherwise, this function may
+ *              have wrong result.
+ *
+ *         - The result of this function could be not correct when using
+ * fractional value for HSE crystal.
+ *
+ * @param  None
+ * @retval None
+ */
 void SystemCoreClockUpdate(void)
 {
-  uint32_t tmp = 0U, msirange = 0U, pllvco = 0U, pllr = 2U, pllsource = 0U, pllm = 2U;
+    uint32_t tmp = 0U, msirange = 0U, pllvco = 0U, pllr = 2U, pllsource = 0U,
+             pllm = 2U;
 
-  /* Get MSI Range frequency--------------------------------------------------*/
-  if((RCC->CR & RCC_CR_MSIRGSEL) == RESET)
-  { /* MSISRANGE from RCC_CSR applies */
-    msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> 8U;
-  }
-  else
-  { /* MSIRANGE from RCC_CR applies */
-    msirange = (RCC->CR & RCC_CR_MSIRANGE) >> 4U;
-  }
-  /*MSI frequency range in HZ*/
-  msirange = MSIRangeTable[msirange];
+    /* Get MSI Range
+     * frequency--------------------------------------------------*/
+    if((RCC->CR & RCC_CR_MSIRGSEL) == RESET)
+    { /* MSISRANGE from RCC_CSR applies */
+        msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> 8U;
+    }
+    else
+    { /* MSIRANGE from RCC_CR applies */
+        msirange = (RCC->CR & RCC_CR_MSIRANGE) >> 4U;
+    }
+    /*MSI frequency range in HZ*/
+    msirange = MSIRangeTable[msirange];
 
-  /* Get SYSCLK source -------------------------------------------------------*/
-  switch (RCC->CFGR & RCC_CFGR_SWS)
-  {
-    case 0x00:  /* MSI used as system clock source */
-      SystemCoreClock = msirange;
-      break;
+    /* Get SYSCLK source
+     * -------------------------------------------------------*/
+    switch(RCC->CFGR & RCC_CFGR_SWS)
+    {
+        case 0x00: /* MSI used as system clock source */
+            SystemCoreClock = msirange;
+            break;
 
-    case 0x04:  /* HSI used as system clock source */
-      SystemCoreClock = HSI_VALUE;
-      break;
+        case 0x04: /* HSI used as system clock source */
+            SystemCoreClock = HSI_VALUE;
+            break;
 
-    case 0x08:  /* HSE used as system clock source */
-      SystemCoreClock = HSE_VALUE;
-      break;
+        case 0x08: /* HSE used as system clock source */
+            SystemCoreClock = HSE_VALUE;
+            break;
 
-    case 0x0C:  /* PLL used as system clock  source */
-      /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
-         SYSCLK = PLL_VCO / PLLR
-         */
-      pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
-      pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4U) + 1U ;
+        case 0x0C: /* PLL used as system clock  source */
+            /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
+               SYSCLK = PLL_VCO / PLLR
+               */
+            pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+            pllm      = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4U) + 1U;
 
-      switch (pllsource)
-      {
-        case 0x02:  /* HSI used as PLL clock source */
-          pllvco = (HSI_VALUE / pllm);
-          break;
+            switch(pllsource)
+            {
+                case 0x02: /* HSI used as PLL clock source */
+                    pllvco = (HSI_VALUE / pllm);
+                    break;
 
-        case 0x03:  /* HSE used as PLL clock source */
-          pllvco = (HSE_VALUE / pllm);
-          break;
+                case 0x03: /* HSE used as PLL clock source */
+                    pllvco = (HSE_VALUE / pllm);
+                    break;
 
-        default:    /* MSI used as PLL clock source */
-          pllvco = (msirange / pllm);
-          break;
-      }
-      pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8U);
-      pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25U) + 1U) * 2U;
-      SystemCoreClock = pllvco/pllr;
-      break;
+                default: /* MSI used as PLL clock source */
+                    pllvco = (msirange / pllm);
+                    break;
+            }
+            pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8U);
+            pllr   = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25U) + 1U) * 2U;
+            SystemCoreClock = pllvco / pllr;
+            break;
 
-    default:
-      SystemCoreClock = msirange;
-      break;
-  }
-  /* Compute HCLK clock frequency --------------------------------------------*/
-  /* Get HCLK prescaler */
-  tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4U)];
-  /* HCLK clock frequency */
-  SystemCoreClock >>= tmp;
+        default:
+            SystemCoreClock = msirange;
+            break;
+    }
+    /* Compute HCLK clock frequency
+     * --------------------------------------------*/
+    /* Get HCLK prescaler */
+    tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4U)];
+    /* HCLK clock frequency */
+    SystemCoreClock >>= tmp;
 }
 
+/**
+ * @}
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
+ * @}
+ */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/projects/STM32L496-Discovery/include/bsp_driver_sd.h
+++ b/projects/STM32L496-Discovery/include/bsp_driver_sd.h
@@ -5,35 +5,44 @@
 #include "stm32l4xx_hal.h"
 
 /* Exported types ------------------------------------------------------------*/
-#define BSP_SD_CardInfo             HAL_SD_CardInfoTypeDef
+#define BSP_SD_CardInfo HAL_SD_CardInfoTypeDef
 
 /* Exported constants --------------------------------------------------------*/
-#define MSD_OK                      ((uint8_t)0x00)
-#define MSD_ERROR                   ((uint8_t)0x01)
-#define MSD_ERROR_SD_NOT_PRESENT    ((uint8_t)0x02)
+#define MSD_OK                   ((uint8_t)0x00)
+#define MSD_ERROR                ((uint8_t)0x01)
+#define MSD_ERROR_SD_NOT_PRESENT ((uint8_t)0x02)
 
-#define SD_TRANSFER_OK              ((uint8_t)0x00)
-#define SD_TRANSFER_BUSY            ((uint8_t)0x01)
-#define SD_TRANSFER_ERROR           ((uint8_t)0x02)
+#define SD_TRANSFER_OK    ((uint8_t)0x00)
+#define SD_TRANSFER_BUSY  ((uint8_t)0x01)
+#define SD_TRANSFER_ERROR ((uint8_t)0x02)
 
-#define SD_PRESENT                  ((uint8_t)0x01)
-#define SD_NOT_PRESENT              ((uint8_t)0x00)
+#define SD_PRESENT     ((uint8_t)0x01)
+#define SD_NOT_PRESENT ((uint8_t)0x00)
 
-#define SD_DATATIMEOUT              (150U)  /* ms */
+#define SD_DATATIMEOUT (150U) /* ms */
 
-#define SDMMC_IRQ_PRIO              1
-#define SD_DMA_IRQ_PRIO             2
+#define SDMMC_IRQ_PRIO  1
+#define SD_DMA_IRQ_PRIO 2
 
 /* Exported functions --------------------------------------------------------*/
 uint8_t BSP_SD_Init(void);
 uint8_t BSP_SD_DeInit(void);
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks);
-uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks);
+uint8_t BSP_SD_ReadBlocks(uint32_t* pData,
+                          uint32_t  ReadAddr,
+                          uint32_t  NumOfBlocks,
+                          uint32_t  Timeout);
+uint8_t BSP_SD_WriteBlocks(uint32_t* pData,
+                           uint32_t  WriteAddr,
+                           uint32_t  NumOfBlocks,
+                           uint32_t  Timeout);
+uint8_t
+        BSP_SD_ReadBlocks_DMA(uint32_t* pData, uint32_t ReadAddr, uint32_t NumOfBlocks);
+uint8_t BSP_SD_WriteBlocks_DMA(uint32_t* pData,
+                               uint32_t  WriteAddr,
+                               uint32_t  NumOfBlocks);
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr);
 uint8_t BSP_SD_GetCardState(void);
-void    BSP_SD_GetCardInfo(BSP_SD_CardInfo *CardInfo);
+void    BSP_SD_GetCardInfo(BSP_SD_CardInfo* CardInfo);
 uint8_t BSP_SD_IsDetected(void);
 
 __weak void BSP_SD_AbortCallback(void);

--- a/projects/STM32L496-Discovery/include/fatfs.h
+++ b/projects/STM32L496-Discovery/include/fatfs.h
@@ -2,7 +2,7 @@
 #define __fatfs_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/

--- a/projects/STM32L496-Discovery/include/ffconf.h
+++ b/projects/STM32L496-Discovery/include/ffconf.h
@@ -1,5 +1,5 @@
 #ifndef _FFCONF
-#define _FFCONF 68300	/* Revision ID */
+#define _FFCONF 68300 /* Revision ID */
 
 /*-----------------------------------------------------------------------------/
 / Additional user header to be used
@@ -11,13 +11,13 @@
 / Function Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _FS_READONLY        1      /* 0:Read/Write or 1:Read only */
+#define _FS_READONLY 1 /* 0:Read/Write or 1:Read only */
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
 /  and optional writing functions as well. */
 
-#define _FS_MINIMIZE        0      /* 0 to 3 */
+#define _FS_MINIMIZE 0 /* 0 to 3 */
 /* This option defines minimization level to remove some basic API functions.
 /
 /   0: All basic functions are enabled.
@@ -26,7 +26,7 @@
 /   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 /   3: f_lseek() function is removed in addition to 2. */
 
-#define _USE_STRFUNC        2      /* 0:Disable or 1-2:Enable */
+#define _USE_STRFUNC 2 /* 0:Disable or 1-2:Enable */
 /* This option switches string functions, f_gets(), f_putc(), f_puts() and
 /  f_printf().
 /
@@ -34,35 +34,37 @@
 /  1: Enable without LF-CRLF conversion.
 /  2: Enable with LF-CRLF conversion. */
 
-#define _USE_FIND           0
+#define _USE_FIND 0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 
-#define _USE_MKFS           1
+#define _USE_MKFS 1
 /* This option switches f_mkfs() function. (0:Disable or 1:Enable) */
 
-#define _USE_FASTSEEK       1
+#define _USE_FASTSEEK 1
 /* This option switches fast seek feature. (0:Disable or 1:Enable) */
 
-#define	_USE_EXPAND         0
+#define _USE_EXPAND 0
 /* This option switches f_expand function. (0:Disable or 1:Enable) */
 
-#define _USE_CHMOD          0
-/* This option switches attribute manipulation functions, f_chmod() and f_utime().
-/  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this option. */
+#define _USE_CHMOD 0
+/* This option switches attribute manipulation functions, f_chmod() and
+f_utime().
+/  (0:Disable or 1:Enable) Also _FS_READONLY needs to be 0 to enable this
+option. */
 
-#define _USE_LABEL          0
+#define _USE_LABEL 0
 /* This option switches volume label functions, f_getlabel() and f_setlabel().
 /  (0:Disable or 1:Enable) */
 
-#define _USE_FORWARD        0
+#define _USE_FORWARD 0
 /* This option switches f_forward() function. (0:Disable or 1:Enable) */
 
 /*-----------------------------------------------------------------------------/
 / Locale and Namespace Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _CODE_PAGE          850
+#define _CODE_PAGE 850
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect setting of the code page can cause a file open failure.
 /
@@ -90,8 +92,8 @@
 /   950 - Traditional Chinese (DBCS)
 */
 
-#define _USE_LFN            1       /* 0 to 3 */
-#define _MAX_LFN            255     /* Maximum LFN length to handle (12 to 255) */
+#define _USE_LFN 1   /* 0 to 3 */
+#define _MAX_LFN 255 /* Maximum LFN length to handle (12 to 255) */
 /* The _USE_LFN switches the support of long file name (LFN).
 /
 /   0: Disable support of LFN. _MAX_LFN has no effect.
@@ -99,22 +101,23 @@
 /   2: Enable LFN with dynamic working buffer on the STACK.
 /   3: Enable LFN with dynamic working buffer on the HEAP.
 /
-/  To enable the LFN, Unicode handling functions (option/unicode.c) must be added
-/  to the project. The working buffer occupies (_MAX_LFN + 1) * 2 bytes and
-/  additional 608 bytes at exFAT enabled. _MAX_LFN can be in range from 12 to 255.
-/  It should be set 255 to support full featured LFN operations.
-/  When use stack for the working buffer, take care on stack overflow. When use heap
-/  memory for the working buffer, memory management functions, ff_memalloc() and
+/  To enable the LFN, Unicode handling functions (option/unicode.c) must be
+added /  to the project. The working buffer occupies (_MAX_LFN + 1) * 2 bytes
+and /  additional 608 bytes at exFAT enabled. _MAX_LFN can be in range from 12
+to 255. /  It should be set 255 to support full featured LFN operations. /  When
+use stack for the working buffer, take care on stack overflow. When use heap /
+memory for the working buffer, memory management functions, ff_memalloc() and
 /  ff_memfree(), must be added to the project. */
 
-#define _LFN_UNICODE        0       /* 0:ANSI/OEM or 1:Unicode */
+#define _LFN_UNICODE 0 /* 0:ANSI/OEM or 1:Unicode */
 /* This option switches character encoding on the API. (0:ANSI/OEM or 1:UTF-16)
 /  To use Unicode string for the path name, enable LFN and set _LFN_UNICODE = 1.
 /  This option also affects behavior of string I/O functions. */
 
-#define _STRF_ENCODE        3
-/* When _LFN_UNICODE == 1, this option selects the character encoding ON THE FILE to
-/  be read/written via string I/O functions, f_gets(), f_putc(), f_puts and f_printf().
+#define _STRF_ENCODE 3
+/* When _LFN_UNICODE == 1, this option selects the character encoding ON THE
+FILE to /  be read/written via string I/O functions, f_gets(), f_putc(), f_puts
+and f_printf().
 /
 /  0: ANSI/OEM
 /  1: UTF-16LE
@@ -123,7 +126,7 @@
 /
 /  This option has no effect when _LFN_UNICODE == 0. */
 
-#define _FS_RPATH           0       /* 0 to 2 */
+#define _FS_RPATH 0 /* 0 to 2 */
 /* This option configures support of relative path.
 /
 /   0: Disable relative path and remove related functions.
@@ -135,41 +138,42 @@
 / Drive/Volume Configurations
 /----------------------------------------------------------------------------*/
 
-#define _VOLUMES            1
+#define _VOLUMES 1
 /* Number of volumes (logical drives) to be used. */
 
 /* USER CODE BEGIN Volumes */
-#define _STR_VOLUME_ID      0       /* 0:Use only 0-9 for drive ID, 1:Use strings for drive ID */
-#define _VOLUME_STRS        "RAM","NAND","CF","SD1","SD2","USB1","USB2","USB3"
+#define _STR_VOLUME_ID \
+    0 /* 0:Use only 0-9 for drive ID, 1:Use strings for drive ID */
+#define _VOLUME_STRS "RAM", "NAND", "CF", "SD1", "SD2", "USB1", "USB2", "USB3"
 /* _STR_VOLUME_ID switches string support of volume ID.
-/  When _STR_VOLUME_ID is set to 1, also pre-defined strings can be used as drive
-/  number in the path name. _VOLUME_STRS defines the drive ID strings for each
-/  logical drives. Number of items must be equal to _VOLUMES. Valid characters for
-/  the drive ID strings are: A-Z and 0-9. */
+/  When _STR_VOLUME_ID is set to 1, also pre-defined strings can be used as
+drive /  number in the path name. _VOLUME_STRS defines the drive ID strings for
+each /  logical drives. Number of items must be equal to _VOLUMES. Valid
+characters for /  the drive ID strings are: A-Z and 0-9. */
 /* USER CODE END Volumes */
 
-#define _MULTI_PARTITION    0       /* 0:Single partition, 1:Multiple partition */
+#define _MULTI_PARTITION 0 /* 0:Single partition, 1:Multiple partition */
 /* This option switches support of multi-partition on a physical drive.
 /  By default (0), each logical drive number is bound to the same physical drive
 /  number and only an FAT volume found on the physical drive will be mounted.
-/  When multi-partition is enabled (1), each logical drive number can be bound to
-/  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
-/  funciton will be available. */
-#define _MIN_SS             512     /* 512, 1024, 2048 or 4096 */
-#define _MAX_SS             512     /* 512, 1024, 2048 or 4096 */
+/  When multi-partition is enabled (1), each logical drive number can be bound
+to /  arbitrary physical drive and partition listed in the VolToPart[]. Also
+f_fdisk() /  funciton will be available. */
+#define _MIN_SS 512 /* 512, 1024, 2048 or 4096 */
+#define _MAX_SS 512 /* 512, 1024, 2048 or 4096 */
 /* These options configure the range of sector size to be supported. (512, 1024,
-/  2048 or 4096) Always set both 512 for most systems, all type of memory cards and
-/  harddisk. But a larger value may be required for on-board flash memory and some
-/  type of optical media. When _MAX_SS is larger than _MIN_SS, FatFs is configured
-/  to variable sector size and GET_SECTOR_SIZE command must be implemented to the
-/  disk_ioctl() function. */
+/  2048 or 4096) Always set both 512 for most systems, all type of memory cards
+and /  harddisk. But a larger value may be required for on-board flash memory
+and some /  type of optical media. When _MAX_SS is larger than _MIN_SS, FatFs is
+configured /  to variable sector size and GET_SECTOR_SIZE command must be
+implemented to the /  disk_ioctl() function. */
 
-#define	_USE_TRIM           0
+#define _USE_TRIM 0
 /* This option switches support of ATA-TRIM. (0:Disable or 1:Enable)
 /  To enable Trim function, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */
 
-#define _FS_NOFSINFO        0       /* 0,1,2 or 3 */
+#define _FS_NOFSINFO 0 /* 0,1,2 or 3 */
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.
@@ -184,44 +188,47 @@
 / System Configurations
 /----------------------------------------------------------------------------*/
 
-#define _FS_TINY            0       /* 0:Normal or 1:Tiny */
+#define _FS_TINY 0 /* 0:Normal or 1:Tiny */
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
-/  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS bytes.
-/  Instead of private sector buffer eliminated from the file object, common sector
-/  buffer in the file system object (FATFS) is used for the file data transfer. */
+/  At the tiny configuration, size of file object (FIL) is reduced _MAX_SS
+bytes. /  Instead of private sector buffer eliminated from the file object,
+common sector /  buffer in the file system object (FATFS) is used for the file
+data transfer. */
 
-#define _FS_EXFAT	        0
+#define _FS_EXFAT 0
 /* This option switches support of exFAT file system. (0:Disable or 1:Enable)
 /  When enable exFAT, also LFN needs to be enabled. (_USE_LFN >= 1)
 /  Note that enabling exFAT discards C89 compatibility. */
 
-#define _FS_NORTC	        0
-#define _NORTC_MON	        6
-#define _NORTC_MDAY	        4
-#define _NORTC_YEAR	        2018
-/* The option _FS_NORTC switches timestamp functiton. If the system does not have
-/  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to disable
-/  the timestamp function. All objects modified by FatFs will have a fixed timestamp
-/  defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR in local time.
-/  To enable timestamp function (_FS_NORTC = 0), get_fattime() function need to be
-/  added to the project to get current time form real-time clock. _NORTC_MON,
-/  _NORTC_MDAY and _NORTC_YEAR have no effect.
-/  These options have no effect at read-only configuration (_FS_READONLY = 1). */
+#define _FS_NORTC   0
+#define _NORTC_MON  6
+#define _NORTC_MDAY 4
+#define _NORTC_YEAR 2018
+/* The option _FS_NORTC switches timestamp functiton. If the system does not
+have /  any RTC function or valid timestamp is not needed, set _FS_NORTC = 1 to
+disable /  the timestamp function. All objects modified by FatFs will have a
+fixed timestamp /  defined by _NORTC_MON, _NORTC_MDAY and _NORTC_YEAR in local
+time. /  To enable timestamp function (_FS_NORTC = 0), get_fattime() function
+need to be /  added to the project to get current time form real-time clock.
+_NORTC_MON, /  _NORTC_MDAY and _NORTC_YEAR have no effect.
+/  These options have no effect at read-only configuration (_FS_READONLY = 1).
+*/
 
-#define _FS_LOCK            0       /* 0:Disable or >=1:Enable */
-/* The option _FS_LOCK switches file lock function to control duplicated file open
-/  and illegal operation to open objects. This option must be 0 when _FS_READONLY
-/  is 1.
+#define _FS_LOCK 0 /* 0:Disable or >=1:Enable */
+/* The option _FS_LOCK switches file lock function to control duplicated file
+open /  and illegal operation to open objects. This option must be 0 when
+_FS_READONLY /  is 1.
 /
-/  0:  Disable file lock function. To avoid volume corruption, application program
-/      should avoid illegal open, remove and rename to the open objects.
-/  >0: Enable file lock function. The value defines how many files/sub-directories
-/      can be opened simultaneously under file lock control. Note that the file
-/      lock control is independent of re-entrancy. */
+/  0:  Disable file lock function. To avoid volume corruption, application
+program /      should avoid illegal open, remove and rename to the open objects.
+/  >0: Enable file lock function. The value defines how many
+files/sub-directories /      can be opened simultaneously under file lock
+control. Note that the file /      lock control is independent of re-entrancy.
+*/
 
-#define _FS_REENTRANT       0       /* 0:Disable or 1:Enable */
-#define _FS_TIMEOUT         1000    /* Timeout period in unit of time ticks */
-#define _SYNC_t             osSemaphoreId
+#define _FS_REENTRANT 0    /* 0:Disable or 1:Enable */
+#define _FS_TIMEOUT   1000 /* Timeout period in unit of time ticks */
+#define _SYNC_t       osSemaphoreId
 /* The option _FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()
@@ -235,15 +242,15 @@
 /      option/syscall.c.
 /
 /  The _FS_TIMEOUT defines timeout period in unit of time tick.
-/  The _SYNC_t defines O/S dependent sync object type. e.g. HANDLE, ID, OS_EVENT*,
-/  SemaphoreHandle_t and etc.. A header file for O/S definitions needs to be
-/  included somewhere in the scope of ff.h. */
+/  The _SYNC_t defines O/S dependent sync object type. e.g. HANDLE, ID,
+OS_EVENT*, /  SemaphoreHandle_t and etc.. A header file for O/S definitions
+needs to be /  included somewhere in the scope of ff.h. */
 
 /* define the ff_malloc ff_free macros as standard malloc free */
 #if !defined(ff_malloc) && !defined(ff_free)
 #include <stdlib.h>
-#define ff_malloc  malloc
-#define ff_free  free
+#define ff_malloc malloc
+#define ff_free   free
 #endif
 
 #endif /* _FFCONF */

--- a/projects/STM32L496-Discovery/include/main.h
+++ b/projects/STM32L496-Discovery/include/main.h
@@ -3,23 +3,23 @@
 
 /*** Application-Specific Configuration ***************************************/
 /* File name of application located on SD card */
-#define CONF_FILENAME       "app-demo.bin"
+#define CONF_FILENAME "app-demo.bin"
 /* For development/debugging: print messages to ST-LINK VCP */
-#define USE_VCP             1
+#define USE_VCP 1
 /******************************************************************************/
 
 /* Hardware Defines ----------------------------------------------------------*/
 /* Joystick center button */
-#define BTN_Port            GPIOC
-#define BTN_Pin             GPIO_PIN_13
+#define BTN_Port GPIOC
+#define BTN_Pin  GPIO_PIN_13
 
 /* LD2 */
-#define LED_G1_Port         GPIOB
-#define LED_G1_Pin          GPIO_PIN_13
+#define LED_G1_Port GPIOB
+#define LED_G1_Pin  GPIO_PIN_13
 
 /* LD3 */
-#define LED_G2_Port         GPIOA
-#define LED_G2_Pin          GPIO_PIN_5
+#define LED_G2_Port GPIOA
+#define LED_G2_Pin  GPIO_PIN_5
 
 /* Enumerations --------------------------------------------------------------*/
 /* Error codes */
@@ -37,18 +37,33 @@ enum eApplicationErrorCodes
 };
 
 /* Hardware Macros -----------------------------------------------------------*/
-#define LED_G1_ON()         HAL_GPIO_WritePin(LED_G1_Port, LED_G1_Pin, GPIO_PIN_RESET)
-#define LED_G1_OFF()        HAL_GPIO_WritePin(LED_G1_Port, LED_G1_Pin, GPIO_PIN_SET)
-#define LED_G1_TG()         HAL_GPIO_TogglePin(LED_G1_Port, LED_G1_Pin)
-#define LED_G2_ON()         HAL_GPIO_WritePin(LED_G2_Port, LED_G2_Pin, GPIO_PIN_SET)
-#define LED_G2_OFF()        HAL_GPIO_WritePin(LED_G2_Port, LED_G2_Pin, GPIO_PIN_RESET)
-#define LED_G2_TG()         HAL_GPIO_TogglePin(LED_G2_Port, LED_G2_Pin)
+#define LED_G1_ON()  HAL_GPIO_WritePin(LED_G1_Port, LED_G1_Pin, GPIO_PIN_RESET)
+#define LED_G1_OFF() HAL_GPIO_WritePin(LED_G1_Port, LED_G1_Pin, GPIO_PIN_SET)
+#define LED_G1_TG()  HAL_GPIO_TogglePin(LED_G1_Port, LED_G1_Pin)
+#define LED_G2_ON()  HAL_GPIO_WritePin(LED_G2_Port, LED_G2_Pin, GPIO_PIN_SET)
+#define LED_G2_OFF() HAL_GPIO_WritePin(LED_G2_Port, LED_G2_Pin, GPIO_PIN_RESET)
+#define LED_G2_TG()  HAL_GPIO_TogglePin(LED_G2_Port, LED_G2_Pin)
 
-#define LED_ALL_ON()        do { LED_G1_ON(); LED_G2_ON(); } while(0)
-#define LED_ALL_OFF()       do { LED_G1_OFF(); LED_G2_OFF(); } while(0)
-#define LED_ALL_TG()        do { LED_G1_TG(); LED_G2_TG(); } while(0)
+#define LED_ALL_ON() \
+    do               \
+    {                \
+        LED_G1_ON(); \
+        LED_G2_ON(); \
+    } while(0)
+#define LED_ALL_OFF() \
+    do                \
+    {                 \
+        LED_G1_OFF(); \
+        LED_G2_OFF(); \
+    } while(0)
+#define LED_ALL_TG() \
+    do               \
+    {                \
+        LED_G1_TG(); \
+        LED_G2_TG(); \
+    } while(0)
 
-#define IS_BTN_PRESSED()    ((HAL_GPIO_ReadPin(BTN_Port, BTN_Pin) == GPIO_PIN_SET) ? 1 : 0)
-
+#define IS_BTN_PRESSED() \
+    ((HAL_GPIO_ReadPin(BTN_Port, BTN_Pin) == GPIO_PIN_SET) ? 1 : 0)
 
 #endif /* __MAIN_H */

--- a/projects/STM32L496-Discovery/include/stm32l4xx_hal_conf.h
+++ b/projects/STM32L496-Discovery/include/stm32l4xx_hal_conf.h
@@ -2,7 +2,7 @@
 #define __STM32L4xx_HAL_CONF_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #include "main.h"
@@ -10,7 +10,7 @@
 /* Exported constants --------------------------------------------------------*/
 
 /* ######################### Custom Definitions ############################# */
-#define SDMMC_HAL_TIMEOUT   500     /* [ms] */
+#define SDMMC_HAL_TIMEOUT 500 /* [ms] */
 
 /* ########################## Module Selection ############################## */
 #define HAL_MODULE_ENABLED
@@ -62,107 +62,120 @@
 //#define HAL_USART_MODULE_ENABLED
 //#define HAL_WWDG_MODULE_ENABLED
 
-/* ########################## Oscillator Values adaptation ####################*/
+/* ######################### Oscillator Values adaptation ####################*/
 /**
-  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
-  *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSE is used as system clock source, directly or through the PLL).
-  */
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+ * @brief Adjust the value of External High Speed oscillator (HSE) used in your
+ * application. This value is used by the RCC HAL module to compute the system
+ * frequency (when HSE is used as system clock source, directly or through the
+ * PLL).
+ */
+#if !defined(HSE_VALUE)
+#define HSE_VALUE \
+    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
+#endif                   /* HSE_VALUE */
 
-#if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100U)   /*!< Time out for HSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
-
-/**
-  * @brief Internal Multiple Speed oscillator (MSI) default value.
-  *        This value is the default MSI range value after Reset.
-  */
-#if !defined  (MSI_VALUE)
-  #define MSI_VALUE    ((uint32_t)4000000U) /*!< Value of the Internal oscillator in Hz*/
-#endif /* MSI_VALUE */
-/**
-  * @brief Internal High Speed oscillator (HSI) value.
-  *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSI is used as system clock source, directly or through the PLL).
-  */
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
+#if !defined(HSE_STARTUP_TIMEOUT)
+#define HSE_STARTUP_TIMEOUT \
+    ((uint32_t)100U) /*!< Time out for HSE start up, in ms */
+#endif               /* HSE_STARTUP_TIMEOUT */
 
 /**
-  * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and RNG.
-  *        This internal oscillator is mainly dedicated to provide a high precision clock to
-  *        the USB peripheral by means of a special Clock Recovery System (CRS) circuitry.
-  *        When the CRS is not used, the HSI48 RC oscillator runs on it default frequency
-  *        which is subject to manufacturing process variations.
-  */
-#if !defined  (HSI48_VALUE)
- #define HSI48_VALUE   ((uint32_t)48000000U) /*!< Value of the Internal High Speed oscillator for USB FS/SDMMC/RNG in Hz.
-                                              The real value my vary depending on manufacturing process variations.*/
-#endif /* HSI48_VALUE */
+ * @brief Internal Multiple Speed oscillator (MSI) default value.
+ *        This value is the default MSI range value after Reset.
+ */
+#if !defined(MSI_VALUE)
+#define MSI_VALUE \
+    ((uint32_t)4000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif                   /* MSI_VALUE */
+/**
+ * @brief Internal High Speed oscillator (HSI) value.
+ *        This value is used by the RCC HAL module to compute the system
+ * frequency (when HSI is used as system clock source, directly or through the
+ * PLL).
+ */
+#if !defined(HSI_VALUE)
+#define HSI_VALUE \
+    ((uint32_t)16000000U) /*!< Value of the Internal oscillator in Hz*/
+#endif                    /* HSI_VALUE */
 
 /**
-  * @brief Internal Low Speed oscillator (LSI) value.
-  */
-#if !defined  (LSI_VALUE)
- #define LSI_VALUE  ((uint32_t)32000U)       /*!< LSI Typical Value in Hz*/
-#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
-                                             The real value may vary depending on the variations
-                                             in voltage and temperature.*/
+ * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and
+ * RNG. This internal oscillator is mainly dedicated to provide a high precision
+ * clock to the USB peripheral by means of a special Clock Recovery System (CRS)
+ * circuitry. When the CRS is not used, the HSI48 RC oscillator runs on it
+ * default frequency which is subject to manufacturing process variations.
+ */
+#if !defined(HSI48_VALUE)
+#define HSI48_VALUE                                                            \
+    ((uint32_t)48000000U) /*!< Value of the Internal High Speed oscillator for \
+                           USB FS/SDMMC/RNG in Hz. The real value my vary      \
+                           depending on manufacturing process variations.*/
+#endif                    /* HSI48_VALUE */
 
 /**
-  * @brief External Low Speed oscillator (LSE) value.
-  *        This value is used by the UART, RTC HAL module to compute the system frequency
-  */
-#if !defined  (LSE_VALUE)
-  #define LSE_VALUE    ((uint32_t)32768U) /*!< Value of the External oscillator in Hz*/
-#endif /* LSE_VALUE */
-
-#if !defined  (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000U)   /*!< Time out for LSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
+ * @brief Internal Low Speed oscillator (LSI) value.
+ */
+#if !defined(LSI_VALUE)
+#define LSI_VALUE ((uint32_t)32000U) /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */ /*!< Value of the Internal Low Speed oscillator in Hz \
+                        The real value may vary depending on the variations  \
+                        in voltage and temperature.*/
 
 /**
-  * @brief External clock source for SAI1 peripheral
-  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
-  *        frequency.
-  */
-#if !defined  (EXTERNAL_SAI1_CLOCK_VALUE)
-  #define EXTERNAL_SAI1_CLOCK_VALUE    ((uint32_t)2097000U) /*!< Value of the SAI1 External clock source in Hz*/
-#endif /* EXTERNAL_SAI1_CLOCK_VALUE */
+ * @brief External Low Speed oscillator (LSE) value.
+ *        This value is used by the UART, RTC HAL module to compute the system
+ * frequency
+ */
+#if !defined(LSE_VALUE)
+#define LSE_VALUE \
+    ((uint32_t)32768U) /*!< Value of the External oscillator in Hz*/
+#endif                 /* LSE_VALUE */
+
+#if !defined(LSE_STARTUP_TIMEOUT)
+#define LSE_STARTUP_TIMEOUT \
+    ((uint32_t)5000U) /*!< Time out for LSE start up, in ms */
+#endif                /* HSE_STARTUP_TIMEOUT */
 
 /**
-  * @brief External clock source for SAI2 peripheral
-  *        This value is used by the RCC HAL module to compute the SAI1 & SAI2 clock source
-  *        frequency.
-  */
-#if !defined  (EXTERNAL_SAI2_CLOCK_VALUE)
-  #define EXTERNAL_SAI2_CLOCK_VALUE    ((uint32_t)2097000U) /*!< Value of the SAI2 External clock source in Hz*/
-#endif /* EXTERNAL_SAI2_CLOCK_VALUE */
+ * @brief External clock source for SAI1 peripheral
+ *        This value is used by the RCC HAL module to compute the SAI1 & SAI2
+ * clock source frequency.
+ */
+#if !defined(EXTERNAL_SAI1_CLOCK_VALUE)
+#define EXTERNAL_SAI1_CLOCK_VALUE \
+    ((uint32_t)2097000U) /*!< Value of the SAI1 External clock source in Hz*/
+#endif                   /* EXTERNAL_SAI1_CLOCK_VALUE */
+
+/**
+ * @brief External clock source for SAI2 peripheral
+ *        This value is used by the RCC HAL module to compute the SAI1 & SAI2
+ * clock source frequency.
+ */
+#if !defined(EXTERNAL_SAI2_CLOCK_VALUE)
+#define EXTERNAL_SAI2_CLOCK_VALUE \
+    ((uint32_t)2097000U) /*!< Value of the SAI2 External clock source in Hz*/
+#endif                   /* EXTERNAL_SAI2_CLOCK_VALUE */
 
 /* Tip: To avoid modifying this file each time you need to use different HSE,
    ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
 /* ########################### System Configuration ######################### */
 /**
-  * @brief This is the HAL system configuration section
-  */
+ * @brief This is the HAL system configuration section
+ */
 
-#define  VDD_VALUE                  ((uint32_t)3000U) /*!< Value of VDD in mv */
-#define  TICK_INT_PRIORITY          ((uint32_t)0U)    /*!< tick interrupt priority */
-#define  USE_RTOS                   0U
-#define  PREFETCH_ENABLE            0U
-#define  INSTRUCTION_CACHE_ENABLE   1U
-#define  DATA_CACHE_ENABLE          1U
+#define VDD_VALUE                ((uint32_t)3000U) /*!< Value of VDD in mv */
+#define TICK_INT_PRIORITY        ((uint32_t)0U) /*!< tick interrupt priority */
+#define USE_RTOS                 0U
+#define PREFETCH_ENABLE          0U
+#define INSTRUCTION_CACHE_ENABLE 1U
+#define DATA_CACHE_ENABLE        1U
 
 /* ########################## Assert Selection ############################## */
 /**
-  * @brief Uncomment the line below to expanse the "assert_param" macro in the
-  *        HAL drivers code
-  */
+ * @brief Uncomment the line below to expanse the "assert_param" macro in the
+ *        HAL drivers code
+ */
 /* #define USE_FULL_ASSERT    1U */
 
 /* ################## SPI peripheral configuration ########################## */
@@ -172,214 +185,215 @@
  * Deactivated: CRC code cleaned from driver
  */
 
-#define USE_SPI_CRC                 0U
+#define USE_SPI_CRC 0U
 
 /* Includes ------------------------------------------------------------------*/
 /**
-  * @brief Include module's header file
-  */
+ * @brief Include module's header file
+ */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-  #include "stm32l4xx_hal_rcc.h"
-  #include "stm32l4xx_hal_rcc_ex.h"
+#include "stm32l4xx_hal_rcc.h"
+#include "stm32l4xx_hal_rcc_ex.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-  #include "stm32l4xx_hal_gpio.h"
+#include "stm32l4xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-  #include "stm32l4xx_hal_dma.h"
-  #include "stm32l4xx_hal_dma_ex.h"
+#include "stm32l4xx_hal_dma.h"
+#include "stm32l4xx_hal_dma_ex.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
 
 #ifdef HAL_DFSDM_MODULE_ENABLED
-  #include "stm32l4xx_hal_dfsdm.h"
+#include "stm32l4xx_hal_dfsdm.h"
 #endif /* HAL_DFSDM_MODULE_ENABLED */
 
 #ifdef HAL_CORTEX_MODULE_ENABLED
-  #include "stm32l4xx_hal_cortex.h"
+#include "stm32l4xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-  #include "stm32l4xx_hal_adc.h"
+#include "stm32l4xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_CAN_MODULE_ENABLED
-  #include "stm32l4xx_hal_can.h"
+#include "stm32l4xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-  #include "stm32l4xx_hal_comp.h"
+#include "stm32l4xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-  #include "stm32l4xx_hal_crc.h"
+#include "stm32l4xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_CRYP_MODULE_ENABLED
-  #include "stm32l4xx_hal_cryp.h"
+#include "stm32l4xx_hal_cryp.h"
 #endif /* HAL_CRYP_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-  #include "stm32l4xx_hal_dac.h"
+#include "stm32l4xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_DCMI_MODULE_ENABLED
-  #include "stm32l4xx_hal_dcmi.h"
+#include "stm32l4xx_hal_dcmi.h"
 #endif /* HAL_DCMI_MODULE_ENABLED */
 
 #ifdef HAL_DMA2D_MODULE_ENABLED
-  #include "stm32l4xx_hal_dma2d.h"
+#include "stm32l4xx_hal_dma2d.h"
 #endif /* HAL_DMA2D_MODULE_ENABLED */
 
 #ifdef HAL_DSI_MODULE_ENABLED
-  #include "stm32l4xx_hal_dsi.h"
+#include "stm32l4xx_hal_dsi.h"
 #endif /* HAL_DSI_MODULE_ENABLED */
 
 #ifdef HAL_FIREWALL_MODULE_ENABLED
-  #include "stm32l4xx_hal_firewall.h"
+#include "stm32l4xx_hal_firewall.h"
 #endif /* HAL_FIREWALL_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-  #include "stm32l4xx_hal_flash.h"
+#include "stm32l4xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_HASH_MODULE_ENABLED
-  #include "stm32l4xx_hal_hash.h"
+#include "stm32l4xx_hal_hash.h"
 #endif /* HAL_HASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-  #include "stm32l4xx_hal_sram.h"
+#include "stm32l4xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-  #include "stm32l4xx_hal_nor.h"
+#include "stm32l4xx_hal_nor.h"
 #endif /* HAL_NOR_MODULE_ENABLED */
 
 #ifdef HAL_NAND_MODULE_ENABLED
-  #include "stm32l4xx_hal_nand.h"
+#include "stm32l4xx_hal_nand.h"
 #endif /* HAL_NAND_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
-  #include "stm32l4xx_hal_i2c.h"
+#include "stm32l4xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-  #include "stm32l4xx_hal_iwdg.h"
+#include "stm32l4xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_LCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_lcd.h"
+#include "stm32l4xx_hal_lcd.h"
 #endif /* HAL_LCD_MODULE_ENABLED */
 
 #ifdef HAL_LPTIM_MODULE_ENABLED
-  #include "stm32l4xx_hal_lptim.h"
+#include "stm32l4xx_hal_lptim.h"
 #endif /* HAL_LPTIM_MODULE_ENABLED */
 
 #ifdef HAL_LTDC_MODULE_ENABLED
-  #include "stm32l4xx_hal_ltdc.h"
+#include "stm32l4xx_hal_ltdc.h"
 #endif /* HAL_LTDC_MODULE_ENABLED */
 
 #ifdef HAL_OPAMP_MODULE_ENABLED
-  #include "stm32l4xx_hal_opamp.h"
+#include "stm32l4xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_OSPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_ospi.h"
+#include "stm32l4xx_hal_ospi.h"
 #endif /* HAL_OSPI_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-  #include "stm32l4xx_hal_pwr.h"
+#include "stm32l4xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_QSPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_qspi.h"
+#include "stm32l4xx_hal_qspi.h"
 #endif /* HAL_QSPI_MODULE_ENABLED */
 
 #ifdef HAL_RNG_MODULE_ENABLED
-  #include "stm32l4xx_hal_rng.h"
+#include "stm32l4xx_hal_rng.h"
 #endif /* HAL_RNG_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-  #include "stm32l4xx_hal_rtc.h"
+#include "stm32l4xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SAI_MODULE_ENABLED
-  #include "stm32l4xx_hal_sai.h"
+#include "stm32l4xx_hal_sai.h"
 #endif /* HAL_SAI_MODULE_ENABLED */
 
 #ifdef HAL_SD_MODULE_ENABLED
-  #include "stm32l4xx_hal_sd.h"
+#include "stm32l4xx_hal_sd.h"
 #endif /* HAL_SD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
-  #include "stm32l4xx_hal_smbus.h"
+#include "stm32l4xx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
-  #include "stm32l4xx_hal_spi.h"
+#include "stm32l4xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_SWPMI_MODULE_ENABLED
-  #include "stm32l4xx_hal_swpmi.h"
+#include "stm32l4xx_hal_swpmi.h"
 #endif /* HAL_SWPMI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-  #include "stm32l4xx_hal_tim.h"
+#include "stm32l4xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-  #include "stm32l4xx_hal_tsc.h"
+#include "stm32l4xx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-  #include "stm32l4xx_hal_uart.h"
+#include "stm32l4xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-  #include "stm32l4xx_hal_usart.h"
+#include "stm32l4xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-  #include "stm32l4xx_hal_irda.h"
+#include "stm32l4xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-  #include "stm32l4xx_hal_smartcard.h"
+#include "stm32l4xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-  #include "stm32l4xx_hal_wwdg.h"
+#include "stm32l4xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_pcd.h"
+#include "stm32l4xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_HCD_MODULE_ENABLED
-  #include "stm32l4xx_hal_hcd.h"
+#include "stm32l4xx_hal_hcd.h"
 #endif /* HAL_HCD_MODULE_ENABLED */
 
 #ifdef HAL_GFXMMU_MODULE_ENABLED
-  #include "stm32l4xx_hal_gfxmmu.h"
+#include "stm32l4xx_hal_gfxmmu.h"
 #endif /* HAL_GFXMMU_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 /**
-  * @brief  The assert_param macro is used for function's parameters check.
-  * @param  expr: If expr is false, it calls assert_failed function
-  *         which reports the name of the source file and the source
-  *         line number of the call that failed.
-  *         If expr is true, it returns no value.
-  * @retval None
-  */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+ * @brief  The assert_param macro is used for function's parameters check.
+ * @param  expr: If expr is false, it calls assert_failed function
+ *         which reports the name of the source file and the source
+ *         line number of the call that failed.
+ *         If expr is true, it returns no value.
+ * @retval None
+ */
+#define assert_param(expr) \
+    ((expr) ? (void)0U : assert_failed((uint8_t*)__FILE__, __LINE__))
 /* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+void assert_failed(uint8_t* file, uint32_t line);
 #else
-  #define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */
 
 #ifdef __cplusplus

--- a/projects/STM32L496-Discovery/include/stm32l4xx_it.h
+++ b/projects/STM32L496-Discovery/include/stm32l4xx_it.h
@@ -2,7 +2,7 @@
 #define __STM32L4xx_IT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/

--- a/projects/STM32L496-Discovery/source/bsp_driver_sd.c
+++ b/projects/STM32L496-Discovery/source/bsp_driver_sd.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   bsp_driver_sd.c
-  * @brief  SD BSP driver
-  *	        This file contains the implementation of the SD BSP driver used by
-  *         the FatFs module. The driver uses the HAL library of ST.
-  *
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   bsp_driver_sd.c
+ * @brief  SD BSP driver
+ *	       This file contains the implementation of the SD BSP driver used by
+ *         the FatFs module. The driver uses the HAL library of ST.
+ *
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "bsp_driver_sd.h"
 
@@ -19,38 +19,38 @@
 SD_HandleTypeDef hsd1;
 
 /* Private function prototypes -----------------------------------------------*/
-static void BSP_SD_MspInit(void);
-static void BSP_SD_MspDeInit(void);
-static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd);
-static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef *hsd);
+static void              BSP_SD_MspInit(void);
+static void              BSP_SD_MspDeInit(void);
+static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef* hsd);
+static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef* hsd);
 
 /* External function prototypes ----------------------------------------------*/
 void Error_Handler(void);
 
 /**
-  * @brief  Initializes the SD card device.
-  * @retval SD status
-  */
+ * @brief  Initializes the SD card device.
+ * @retval SD status
+ */
 uint8_t BSP_SD_Init(void)
 {
     uint8_t tries;
 
     /* Check if the SD card is plugged in the slot */
-    if (BSP_SD_IsDetected() != SD_PRESENT)
+    if(BSP_SD_IsDetected() != SD_PRESENT)
     {
         return MSD_ERROR_SD_NOT_PRESENT;
     }
 
     /* SD interface configuration */
-    hsd1.Instance = SDMMC1;
-    hsd1.Init.ClockEdge = SDMMC_CLOCK_EDGE_RISING;
-    hsd1.Init.ClockBypass = SDMMC_CLOCK_BYPASS_DISABLE;
-    hsd1.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE;
-    hsd1.Init.BusWide = SDMMC_BUS_WIDE_1B;
+    hsd1.Instance                 = SDMMC1;
+    hsd1.Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
+    hsd1.Init.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
+    hsd1.Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
+    hsd1.Init.BusWide             = SDMMC_BUS_WIDE_1B;
     hsd1.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_ENABLE;
-    hsd1.Init.ClockDiv = 0;
+    hsd1.Init.ClockDiv            = 0;
 
-    for(tries=0; tries<5; ++tries)
+    for(tries = 0; tries < 5; ++tries)
     {
         /* Msp SD initialization */
         BSP_SD_MspDeInit();
@@ -77,9 +77,9 @@ uint8_t BSP_SD_Init(void)
 }
 
 /**
-  * @brief  De-Initializes the SD card device
-  * @retval None
-  */
+ * @brief  De-Initializes the SD card device
+ * @retval None
+ */
 uint8_t BSP_SD_DeInit(void)
 {
     /* HAL SD de-initialization */
@@ -93,42 +93,47 @@ uint8_t BSP_SD_DeInit(void)
     __HAL_RCC_SDMMC1_RELEASE_RESET();
 
     /* Misc */
-    hsd1.State = HAL_SD_STATE_RESET;
-    hsd1.Context = 0;
-    hsd1.ErrorCode = 0;
-    hsd1.SdCard.CardType = 0;
-    hsd1.SdCard.CardVersion = 0;
-    hsd1.SdCard.Class = 0;
-    hsd1.SdCard.RelCardAdd = 0;
-    hsd1.SdCard.BlockNbr = 0;
-    hsd1.SdCard.BlockSize = 0;
-    hsd1.SdCard.LogBlockNbr = 0;
+    hsd1.State               = HAL_SD_STATE_RESET;
+    hsd1.Context             = 0;
+    hsd1.ErrorCode           = 0;
+    hsd1.SdCard.CardType     = 0;
+    hsd1.SdCard.CardVersion  = 0;
+    hsd1.SdCard.Class        = 0;
+    hsd1.SdCard.RelCardAdd   = 0;
+    hsd1.SdCard.BlockNbr     = 0;
+    hsd1.SdCard.BlockSize    = 0;
+    hsd1.SdCard.LogBlockNbr  = 0;
     hsd1.SdCard.LogBlockSize = 0;
-    hsd1.CSD[0] = 0;
-    hsd1.CSD[1] = 0;
-    hsd1.CSD[2] = 0;
-    hsd1.CSD[3] = 0;
-    hsd1.CID[0] = 0;
-    hsd1.CID[1] = 0;
-    hsd1.CID[2] = 0;
-    hsd1.CID[3] = 0;
+    hsd1.CSD[0]              = 0;
+    hsd1.CSD[1]              = 0;
+    hsd1.CSD[2]              = 0;
+    hsd1.CSD[3]              = 0;
+    hsd1.CID[0]              = 0;
+    hsd1.CID[1]              = 0;
+    hsd1.CID[2]              = 0;
+    hsd1.CID[3]              = 0;
 
-    return  MSD_OK;
+    return MSD_OK;
 }
 
 /**
-  * @brief  Reads block(s) from a specified address in an SD card, in polling mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  ReadAddr: Address from where data is to be read
-  * @param  NumOfBlocks: Number of SD blocks to read
-  * @param  Timeout: Timeout for read operation
-  * @retval SD status
-  */
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout)
+ * @brief  Reads block(s) from a specified address in an SD card, in polling
+ * mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  ReadAddr: Address from where data is to be read
+ * @param  NumOfBlocks: Number of SD blocks to read
+ * @param  Timeout: Timeout for read operation
+ * @retval SD status
+ */
+uint8_t BSP_SD_ReadBlocks(uint32_t* pData,
+                          uint32_t  ReadAddr,
+                          uint32_t  NumOfBlocks,
+                          uint32_t  Timeout)
 {
     uint8_t sd_state = MSD_OK;
 
-    if(HAL_SD_ReadBlocks(&hsd1, (uint8_t *)pData, ReadAddr, NumOfBlocks, Timeout) != HAL_OK)
+    if(HAL_SD_ReadBlocks(&hsd1, (uint8_t*)pData, ReadAddr, NumOfBlocks,
+                         Timeout) != HAL_OK)
     {
         sd_state = MSD_ERROR;
     }
@@ -137,18 +142,23 @@ uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBloc
 }
 
 /**
-  * @brief  Writes block(s) to a specified address in an SD card, in polling mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
-  * @param  NumOfBlocks: Number of SD blocks to write
-  * @param  Timeout: Timeout for write operation
-  * @retval SD status
-  */
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout)
+ * @brief  Writes block(s) to a specified address in an SD card, in polling
+ * mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  WriteAddr: Address from where data is to be written
+ * @param  NumOfBlocks: Number of SD blocks to write
+ * @param  Timeout: Timeout for write operation
+ * @retval SD status
+ */
+uint8_t BSP_SD_WriteBlocks(uint32_t* pData,
+                           uint32_t  WriteAddr,
+                           uint32_t  NumOfBlocks,
+                           uint32_t  Timeout)
 {
     uint8_t sd_state = MSD_OK;
 
-    if(HAL_SD_WriteBlocks(&hsd1, (uint8_t *)pData, WriteAddr, NumOfBlocks, Timeout) != HAL_OK)
+    if(HAL_SD_WriteBlocks(&hsd1, (uint8_t*)pData, WriteAddr, NumOfBlocks,
+                          Timeout) != HAL_OK)
     {
         sd_state = MSD_ERROR;
     }
@@ -157,13 +167,14 @@ uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBl
 }
 
 /**
-  * @brief  Reads block(s) from a specified address in an SD card, in DMA mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  ReadAddr: Address from where data is to be read
-  * @param  NumOfBlocks: Number of SD blocks to read
-  * @retval SD status
-  */
-uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks)
+ * @brief  Reads block(s) from a specified address in an SD card, in DMA mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  ReadAddr: Address from where data is to be read
+ * @param  NumOfBlocks: Number of SD blocks to read
+ * @retval SD status
+ */
+uint8_t
+BSP_SD_ReadBlocks_DMA(uint32_t* pData, uint32_t ReadAddr, uint32_t NumOfBlocks)
 {
     HAL_StatusTypeDef sd_state = HAL_OK;
 
@@ -176,20 +187,23 @@ uint8_t BSP_SD_ReadBlocks_DMA(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOf
     if(sd_state == HAL_OK)
     {
         /* Read block(s) in DMA transfer mode */
-        sd_state = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t *)pData, ReadAddr, NumOfBlocks);
+        sd_state = HAL_SD_ReadBlocks_DMA(&hsd1, (uint8_t*)pData, ReadAddr,
+                                         NumOfBlocks);
     }
 
     return (sd_state == HAL_OK) ? MSD_OK : MSD_ERROR;
 }
 
 /**
-  * @brief  Writes block(s) to a specified address in an SD card, in DMA mode.
-  * @param  pData: Pointer to the buffer that will contain the data to transmit
-  * @param  WriteAddr: Address from where data is to be written
-  * @param  NumOfBlocks: Number of SD blocks to write
-  * @retval SD status
-  */
-uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks)
+ * @brief  Writes block(s) to a specified address in an SD card, in DMA mode.
+ * @param  pData: Pointer to the buffer that will contain the data to transmit
+ * @param  WriteAddr: Address from where data is to be written
+ * @param  NumOfBlocks: Number of SD blocks to write
+ * @retval SD status
+ */
+uint8_t BSP_SD_WriteBlocks_DMA(uint32_t* pData,
+                               uint32_t  WriteAddr,
+                               uint32_t  NumOfBlocks)
 {
     HAL_StatusTypeDef sd_state = HAL_OK;
 
@@ -199,21 +213,22 @@ uint8_t BSP_SD_WriteBlocks_DMA(uint32_t *pData, uint32_t WriteAddr, uint32_t Num
     /* Prepare the dma channel for a read operation */
     sd_state = SD_DMAConfigTx(&hsd1);
 
-    if (sd_state == HAL_OK)
+    if(sd_state == HAL_OK)
     {
         /* Write block(s) in DMA transfer mode */
-        sd_state = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t *)pData, WriteAddr, NumOfBlocks);
+        sd_state = HAL_SD_WriteBlocks_DMA(&hsd1, (uint8_t*)pData, WriteAddr,
+                                          NumOfBlocks);
     }
 
     return (sd_state == HAL_OK) ? MSD_OK : MSD_ERROR;
 }
 
 /**
-  * @brief  Erases the specified memory area of the given SD card.
-  * @param  StartAddr: Start byte address
-  * @param  EndAddr: End byte address
-  * @retval SD status
-  */
+ * @brief  Erases the specified memory area of the given SD card.
+ * @param  StartAddr: Start byte address
+ * @param  EndAddr: End byte address
+ * @retval SD status
+ */
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr)
 {
     uint8_t sd_state = MSD_OK;
@@ -227,13 +242,13 @@ uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr)
 }
 
 /**
-  * @brief  Gets the current SD card data status.
-  * @param  None
-  * @retval Data transfer state.
-  *          This value can be one of the following values:
-  *            @arg  SD_TRANSFER_OK: No data transfer is acting
-  *            @arg  SD_TRANSFER_BUSY: Data transfer is acting
-  */
+ * @brief  Gets the current SD card data status.
+ * @param  None
+ * @retval Data transfer state.
+ *          This value can be one of the following values:
+ *            @arg  SD_TRANSFER_OK: No data transfer is acting
+ *            @arg  SD_TRANSFER_BUSY: Data transfer is acting
+ */
 uint8_t BSP_SD_GetCardState(void)
 {
     HAL_SD_CardStateTypedef card_state;
@@ -256,11 +271,11 @@ uint8_t BSP_SD_GetCardState(void)
 }
 
 /**
-  * @brief  Get SD information about specific SD card.
-  * @param  CardInfo: Pointer to HAL_SD_CardInfoTypedef structure
-  * @retval None
-  */
-void BSP_SD_GetCardInfo(BSP_SD_CardInfo *CardInfo)
+ * @brief  Get SD information about specific SD card.
+ * @param  CardInfo: Pointer to HAL_SD_CardInfoTypedef structure
+ * @retval None
+ */
+void BSP_SD_GetCardInfo(BSP_SD_CardInfo* CardInfo)
 {
     HAL_SD_GetCardInfo(&hsd1, CardInfo);
 }
@@ -275,90 +290,87 @@ uint8_t BSP_SD_IsDetected(void)
     return SD_PRESENT;
 }
 
-
 /**
-  * @brief SD Abort callbacks
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_AbortCallback(SD_HandleTypeDef *hsd)
+ * @brief SD Abort callbacks
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_AbortCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_AbortCallback();
 }
 
 /**
-  * @brief SD Error callbacks
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_ErrorCallback(SD_HandleTypeDef *hsd)
+ * @brief SD Error callbacks
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_ErrorCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_ErrorCallback();
 }
 
 /**
-  * @brief Rx Transfer completed callback
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_RxCpltCallback(SD_HandleTypeDef *hsd)
+ * @brief Rx Transfer completed callback
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_RxCpltCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_ReadCpltCallback();
 }
 
 /**
-  * @brief Tx Transfer completed callback
-  * @param hsd: SD handle
-  * @retval None
-  */
-void HAL_SD_TxCpltCallback(SD_HandleTypeDef *hsd)
+ * @brief Tx Transfer completed callback
+ * @param hsd: SD handle
+ * @retval None
+ */
+void HAL_SD_TxCpltCallback(SD_HandleTypeDef* hsd)
 {
     BSP_SD_WriteCpltCallback();
 }
 
-
 /**
-  * @brief BSP SD Abort callback
-  * @retval None
-  */
+ * @brief BSP SD Abort callback
+ * @retval None
+ */
 __weak void BSP_SD_AbortCallback(void)
 {
     Error_Handler();
 }
 
 /**
-  * @brief BSP SD Error callback
-  * @retval None
-  */
+ * @brief BSP SD Error callback
+ * @retval None
+ */
 __weak void BSP_SD_ErrorCallback(void)
 {
     Error_Handler();
 }
 
 /**
-  * @brief BSP Rx Transfer completed callback
-  * @retval None
-  */
+ * @brief BSP Rx Transfer completed callback
+ * @retval None
+ */
 __weak void BSP_SD_ReadCpltCallback(void)
 {
     // redefined in sd_diskio
 }
 
 /**
-  * @brief BSP Tx Transfer completed callback
-  * @retval None
-  */
+ * @brief BSP Tx Transfer completed callback
+ * @retval None
+ */
 __weak void BSP_SD_WriteCpltCallback(void)
 {
     // redefined in sd_diskio
 }
 
-
 /**
-  * @brief Initializes the SD MSP.
-  * @param None
-  * @retval None
-  */
+ * @brief Initializes the SD MSP.
+ * @param None
+ * @retval None
+ */
 void BSP_SD_MspInit(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -380,7 +392,8 @@ void BSP_SD_MspInit(void)
     GPIO_InitStruct.Alternate = GPIO_AF12_SDMMC1;
 
     /* GPIOC configuration */
-    GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+    GPIO_InitStruct.Pin =
+        GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     /* GPIOD configuration */
@@ -394,14 +407,14 @@ void BSP_SD_MspInit(void)
     /* DMA initialization should be done here but
      * (as there is only one channel for RX and TX)
      * it is configured and done directly when required.
-    */
+     */
 }
 
 /**
-  * @brief De-Initializes the SD MSP.
-  * @param None
-  * @retval None
-  */
+ * @brief De-Initializes the SD MSP.
+ * @param None
+ * @retval None
+ */
 void BSP_SD_MspDeInit(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -422,7 +435,8 @@ void BSP_SD_MspDeInit(void)
     GPIO_InitStruct.Alternate = 0;
 
     /* GPIOC configuration */
-    GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+    GPIO_InitStruct.Pin =
+        GPIO_PIN_8 | GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     /* GPIOD configuration */
@@ -434,14 +448,14 @@ void BSP_SD_MspDeInit(void)
 }
 
 /**
-  * @brief Configure the DMA to receive data from the SD card
-  * @retval
-  *  HAL_ERROR or HAL_OK
-  */
-static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd)
+ * @brief Configure the DMA to receive data from the SD card
+ * @retval
+ *  HAL_ERROR or HAL_OK
+ */
+static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef* hsd)
 {
     static DMA_HandleTypeDef hdma_rx;
-    HAL_StatusTypeDef status = HAL_ERROR;
+    HAL_StatusTypeDef        status = HAL_ERROR;
 
     /* Configure DMA Rx parameters */
     hdma_rx.Instance                 = DMA2_Channel5;
@@ -473,14 +487,14 @@ static HAL_StatusTypeDef SD_DMAConfigRx(SD_HandleTypeDef *hsd)
 }
 
 /**
-  * @brief Configure the DMA to transmit data to the SD card
-  * @retval
-  *  HAL_ERROR or HAL_OK
-  */
-static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef *hsd)
+ * @brief Configure the DMA to transmit data to the SD card
+ * @retval
+ *  HAL_ERROR or HAL_OK
+ */
+static HAL_StatusTypeDef SD_DMAConfigTx(SD_HandleTypeDef* hsd)
 {
     static DMA_HandleTypeDef hdma_tx;
-    HAL_StatusTypeDef status;
+    HAL_StatusTypeDef        status;
 
     /* Configure DMA Tx parameters */
     hdma_tx.Instance                 = DMA2_Channel5;

--- a/projects/STM32L496-Discovery/source/fatfs.c
+++ b/projects/STM32L496-Discovery/source/fatfs.c
@@ -1,25 +1,25 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   fatfs.c
-  * @brief  FatFS application
-  *         Code for FatFS application
-  *
-  *
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   fatfs.c
+ * @brief  FatFS application
+ *         Code for FatFS application
+ *
+ *
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "fatfs.h"
 #include "main.h"
 
 /* Variables -----------------------------------------------------------------*/
-char  SDPath[4];        /* SD logical drive path */
-FATFS SDFatFs;          /* File system object for SD logical drive */
-FIL   SDFile;           /* File object for SD */
+char  SDPath[4]; /* SD logical drive path */
+FATFS SDFatFs;   /* File system object for SD logical drive */
+FIL   SDFile;    /* File object for SD */
 
 /* Functions -----------------------------------------------------------------*/
 uint8_t FATFS_Init(void)
@@ -33,10 +33,10 @@ uint8_t FATFS_DeInit(void)
 }
 
 /**
-  * @brief  Gets Time from RTC
-  * @param  None
-  * @retval Time in DWORD
-  */
+ * @brief  Gets Time from RTC
+ * @param  None
+ * @retval Time in DWORD
+ */
 DWORD get_fattime(void)
 {
     return (DWORD)0;

--- a/projects/STM32L496-Discovery/source/main.c
+++ b/projects/STM32L496-Discovery/source/main.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   main.c
-  * @brief  Main program
-  *	        This file demonstrates the usage of the bootloader.
-  *
-  * @see    Please refer to README for detailed information.
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   main.c
+ * @brief  Main program
+ *	       This file demonstrates the usage of the bootloader.
+ *
+ * @see    Please refer to README for detailed information.
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "stm32l4xx.h"
 #include "main.h"
@@ -20,13 +20,13 @@
 #include <string.h>
 
 /* Private variables ---------------------------------------------------------*/
-static uint8_t BTNcounter = 0;
+static uint8_t            BTNcounter = 0;
 static UART_HandleTypeDef huart2;
 
 /* External variables --------------------------------------------------------*/
-extern char  SDPath[4];         /* SD logical drive path */
-extern FATFS SDFatFs;           /* File system object for SD logical drive */
-extern FIL   SDFile;            /* File object for SD */
+extern char  SDPath[4]; /* SD logical drive path */
+extern FATFS SDFatFs;   /* File system object for SD logical drive */
+extern FIL   SDFile;    /* File object for SD */
 
 /* Function prototypes -------------------------------------------------------*/
 uint8_t Enter_Bootloader(void);
@@ -48,7 +48,7 @@ int main(void)
     SystemClock_Config();
     GPIO_Init();
 
-#if (USE_VCP)
+#if(USE_VCP)
     UART2_Init();
 #endif /* USE_VCP */
 
@@ -58,7 +58,7 @@ int main(void)
     if(__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST))
     {
         print("OBL flag is active.\n");
-#if (CLEAR_RESET_FLAGS)
+#if(CLEAR_RESET_FLAGS)
         /* Clear system reset flags */
         __HAL_RCC_CLEAR_RESET_FLAGS();
         print("Reset flags cleared.\n");
@@ -67,7 +67,8 @@ int main(void)
 
     /* Check for user action:
         - button is pressed >= 1 second:  Enter Bootloader. LD2 is blinking.
-        - button is pressed >= 4 seconds: Enter ST System Memory. LD3 is blinking.
+        - button is pressed >= 4 seconds: Enter ST System Memory. LD3 is
+          blinking.
         - button is pressed >= 9 seconds: Do nothing, launch application.
     */
     while((IS_BTN_PRESSED()) && (BTNcounter < 90))
@@ -128,7 +129,7 @@ int main(void)
     /* Check if there is application in user flash area */
     if(Bootloader_CheckForApplication() == BL_OK)
     {
-#if (USE_CHECKSUM)
+#if(USE_CHECKSUM)
         /* Verify application checksum */
         if(Bootloader_VerifyChecksum() != BL_OK)
         {
@@ -153,7 +154,7 @@ int main(void)
         /* De-initialize bootloader hardware & peripherals */
         SD_DeInit();
         GPIO_DeInit();
-#if (USE_VCP)
+#if(USE_VCP)
         UART2_DeInit();
 #endif /* USE_VCP */
 
@@ -170,11 +171,11 @@ int main(void)
 }
 
 /**
-  * @brief  This function executes the bootloader sequence.
-  * @param  None
-  * @retval Application error code ::eApplicationErrorCodes
-  *
-  */
+ * @brief  This function executes the bootloader sequence.
+ * @param  None
+ * @retval Application error code ::eApplicationErrorCodes
+ *
+ */
 uint8_t Enter_Bootloader(void)
 {
     FRESULT  fr;
@@ -198,7 +199,8 @@ uint8_t Enter_Bootloader(void)
             HAL_Delay(50);
             if(IS_BTN_PRESSED())
             {
-                print("Disabling write protection and generating system reset...\n");
+                print("Disabling write protection and generating system "
+                      "reset...\n");
                 Bootloader_ConfigProtection(BL_PROTECTION_NONE);
             }
         }
@@ -284,7 +286,7 @@ uint8_t Enter_Bootloader(void)
     do
     {
         data = 0xFFFFFFFFFFFFFFFF;
-        fr = f_read(&SDFile, &data, 8, &num);
+        fr   = f_read(&SDFile, &data, 8, &num);
         if(num)
         {
             status = Bootloader_FlashNext(data);
@@ -294,7 +296,7 @@ uint8_t Enter_Bootloader(void)
             }
             else
             {
-                sprintf(msg, "Programming error at: %lu byte\n", (cntr*8));
+                sprintf(msg, "Programming error at: %lu byte\n", (cntr * 8));
                 print(msg);
 
                 f_close(&SDFile);
@@ -317,7 +319,7 @@ uint8_t Enter_Bootloader(void)
     f_close(&SDFile);
     LED_ALL_OFF();
     print("Programming finished.\n");
-    sprintf(msg, "Flashed: %lu bytes.\n", (cntr*8));
+    sprintf(msg, "Flashed: %lu bytes.\n", (cntr * 8));
     print(msg);
 
     /* Open file for verification */
@@ -340,7 +342,7 @@ uint8_t Enter_Bootloader(void)
     do
     {
         data = 0xFFFFFFFFFFFFFFFF;
-        fr = f_read(&SDFile, &data, 4, &num);
+        fr   = f_read(&SDFile, &data, 4, &num);
         if(num)
         {
             if(*(uint32_t*)addr == (uint32_t)data)
@@ -350,7 +352,7 @@ uint8_t Enter_Bootloader(void)
             }
             else
             {
-                sprintf(msg, "Verification error at: %lu byte.\n", (cntr*4));
+                sprintf(msg, "Verification error at: %lu byte.\n", (cntr * 4));
                 print(msg);
 
                 f_close(&SDFile);
@@ -375,7 +377,7 @@ uint8_t Enter_Bootloader(void)
     print("SD ejected.\n");
 
     /* Enable flash write protection */
-#if (USE_WRITE_PROTECTION)
+#if(USE_WRITE_PROTECTION)
     print("Enablig flash write protection and generating system reset...\n");
     if(Bootloader_ConfigProtection(BL_PROTECTION_WRP) != BL_OK)
     {
@@ -388,10 +390,10 @@ uint8_t Enter_Bootloader(void)
 }
 
 /**
-  * @brief  This function initializes and mounts the SD card.
-  * @param  None
-  * @retval None
-  */
+ * @brief  This function initializes and mounts the SD card.
+ * @param  None
+ * @retval None
+ */
 uint8_t SD_Init(void)
 {
     if(FATFS_Init())
@@ -410,10 +412,10 @@ uint8_t SD_Init(void)
 }
 
 /**
-  * @brief  This function de-initializes the SD card.
-  * @param  None
-  * @retval None
-  */
+ * @brief  This function de-initializes the SD card.
+ * @param  None
+ * @retval None
+ */
 void SD_DeInit(void)
 {
     BSP_SD_DeInit();
@@ -421,22 +423,22 @@ void SD_DeInit(void)
 }
 
 /**
-  * @brief  This function ejects the SD card.
-  * @param  None
-  * @retval None
-  */
+ * @brief  This function ejects the SD card.
+ * @param  None
+ * @retval None
+ */
 void SD_Eject(void)
 {
     f_mount(NULL, (TCHAR const*)SDPath, 0);
 }
 
 /**
-  * @brief  UART2 initialization function. UART2 is used for debugging. The
-  *         data sent over UART2 is forwarded to the USB virtual com port by the
-  *         ST-LINK located on the discovery board.
-  * @param  None
-  * @retval None
-  */
+ * @brief  UART2 initialization function. UART2 is used for debugging. The
+ *         data sent over UART2 is forwarded to the USB virtual com port by the
+ *         ST-LINK located on the discovery board.
+ * @param  None
+ * @retval None
+ */
 void UART2_Init(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -445,42 +447,41 @@ void UART2_Init(void)
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOD_CLK_ENABLE();
 
-    huart2.Instance = USART2;
-    huart2.Init.BaudRate = 115200;
-    huart2.Init.WordLength = UART_WORDLENGTH_8B;
-    huart2.Init.StopBits = UART_STOPBITS_1;
-    huart2.Init.Parity = UART_PARITY_NONE;
-    huart2.Init.Mode = UART_MODE_TX_RX;
-    huart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-    huart2.Init.OverSampling = UART_OVERSAMPLING_16;
-    huart2.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+    huart2.Instance                    = USART2;
+    huart2.Init.BaudRate               = 115200;
+    huart2.Init.WordLength             = UART_WORDLENGTH_8B;
+    huart2.Init.StopBits               = UART_STOPBITS_1;
+    huart2.Init.Parity                 = UART_PARITY_NONE;
+    huart2.Init.Mode                   = UART_MODE_TX_RX;
+    huart2.Init.HwFlowCtl              = UART_HWCONTROL_NONE;
+    huart2.Init.OverSampling           = UART_OVERSAMPLING_16;
+    huart2.Init.OneBitSampling         = UART_ONE_BIT_SAMPLE_DISABLE;
     huart2.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
     if(HAL_UART_Init(&huart2) != HAL_OK)
     {
         Error_Handler();
     }
 
-    GPIO_InitStruct.Pin = GPIO_PIN_6;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Pin       = GPIO_PIN_6;
+    GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull      = GPIO_NOPULL;
+    GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART2;
     HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin = GPIO_PIN_2;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Pin       = GPIO_PIN_2;
+    GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull      = GPIO_NOPULL;
+    GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART2;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
 }
 
 /**
-  * @brief  UART2 de-initialization function.
-  * @param  None
-  * @retval None
-  */
+ * @brief  UART2 de-initialization function.
+ * @param  None
+ * @retval None
+ */
 void UART2_DeInit(void)
 {
     HAL_UART_DeInit(&huart2);
@@ -494,10 +495,10 @@ void UART2_DeInit(void)
 }
 
 /**
-  * @brief  GPIO initialization function for LEDs and push-button.
-  * @param  None
-  * @retval None
-  */
+ * @brief  GPIO initialization function for LEDs and push-button.
+ * @param  None
+ * @retval None
+ */
 void GPIO_Init(void)
 {
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -511,8 +512,8 @@ void GPIO_Init(void)
     LED_G2_OFF();
 
     /* LED_G1_Pin, LED_G2_Pin */
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull  = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 
     GPIO_InitStruct.Pin = LED_G1_Pin;
@@ -522,18 +523,18 @@ void GPIO_Init(void)
     HAL_GPIO_Init(LED_G2_Port, &GPIO_InitStruct);
 
     /* User Button */
-    GPIO_InitStruct.Pin = BTN_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-    GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+    GPIO_InitStruct.Pin   = BTN_Pin;
+    GPIO_InitStruct.Mode  = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull  = GPIO_PULLDOWN;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(BTN_Port, &GPIO_InitStruct);
 }
 
 /**
-  * @brief  GPIO de-initialization function.
-  * @param  None
-  * @retval None
-  */
+ * @brief  GPIO de-initialization function.
+ * @param  None
+ * @retval None
+ */
 void GPIO_DeInit(void)
 {
     HAL_GPIO_DeInit(BTN_Port, BTN_Pin);
@@ -546,36 +547,37 @@ void GPIO_DeInit(void)
 }
 
 /**
-  * @brief  System clock configuration function.
-  * @param  None
-  * @retval None
-  */
+ * @brief  System clock configuration function.
+ * @param  None
+ * @retval None
+ */
 void SystemClock_Config(void)
 {
-    RCC_OscInitTypeDef RCC_OscInitStruct;
-    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+    RCC_OscInitTypeDef       RCC_OscInitStruct;
+    RCC_ClkInitTypeDef       RCC_ClkInitStruct;
     RCC_PeriphCLKInitTypeDef PeriphClkInit;
 
     /* Initializes the CPU, AHB and APB bus clocks */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
-    RCC_OscInitStruct.MSIState = RCC_MSI_ON;
+    RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI;
+    RCC_OscInitStruct.MSIState            = RCC_MSI_ON;
     RCC_OscInitStruct.MSICalibrationValue = 0;
-    RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
-    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
-    RCC_OscInitStruct.PLL.PLLM = 1;
-    RCC_OscInitStruct.PLL.PLLN = 24;
-    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
-    RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
-    RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+    RCC_OscInitStruct.MSIClockRange       = RCC_MSIRANGE_6;
+    RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_MSI;
+    RCC_OscInitStruct.PLL.PLLM            = 1;
+    RCC_OscInitStruct.PLL.PLLN            = 24;
+    RCC_OscInitStruct.PLL.PLLP            = RCC_PLLP_DIV2;
+    RCC_OscInitStruct.PLL.PLLQ            = RCC_PLLQ_DIV2;
+    RCC_OscInitStruct.PLL.PLLR            = RCC_PLLR_DIV2;
     if(HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
     {
         Error_Handler();
     }
 
-    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
-    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                                  RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
@@ -584,15 +586,16 @@ void SystemClock_Config(void)
         Error_Handler();
     }
 
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_SDMMC1 | RCC_PERIPHCLK_USART2;
-    PeriphClkInit.Usart2ClockSelection = RCC_USART2CLKSOURCE_PCLK1;
-    PeriphClkInit.Sdmmc1ClockSelection = RCC_SDMMC1CLKSOURCE_PLLSAI1;
-    PeriphClkInit.PLLSAI1.PLLSAI1Source = RCC_PLLSOURCE_MSI;
-    PeriphClkInit.PLLSAI1.PLLSAI1M = 1;
-    PeriphClkInit.PLLSAI1.PLLSAI1N = 24;
-    PeriphClkInit.PLLSAI1.PLLSAI1P = RCC_PLLP_DIV2;
-    PeriphClkInit.PLLSAI1.PLLSAI1Q = RCC_PLLQ_DIV2;
-    PeriphClkInit.PLLSAI1.PLLSAI1R = RCC_PLLR_DIV2;
+    PeriphClkInit.PeriphClockSelection =
+        RCC_PERIPHCLK_SDMMC1 | RCC_PERIPHCLK_USART2;
+    PeriphClkInit.Usart2ClockSelection    = RCC_USART2CLKSOURCE_PCLK1;
+    PeriphClkInit.Sdmmc1ClockSelection    = RCC_SDMMC1CLKSOURCE_PLLSAI1;
+    PeriphClkInit.PLLSAI1.PLLSAI1Source   = RCC_PLLSOURCE_MSI;
+    PeriphClkInit.PLLSAI1.PLLSAI1M        = 1;
+    PeriphClkInit.PLLSAI1.PLLSAI1N        = 24;
+    PeriphClkInit.PLLSAI1.PLLSAI1P        = RCC_PLLP_DIV2;
+    PeriphClkInit.PLLSAI1.PLLSAI1Q        = RCC_PLLQ_DIV2;
+    PeriphClkInit.PLLSAI1.PLLSAI1R        = RCC_PLLR_DIV2;
     PeriphClkInit.PLLSAI1.PLLSAI1ClockOut = RCC_PLLSAI1_48M2CLK;
     if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK)
     {
@@ -612,10 +615,10 @@ void SystemClock_Config(void)
 }
 
 /**
-  * @brief  HAL MSP callback function
-  * @param  None
-  * @retval None
-  */
+ * @brief  HAL MSP callback function
+ * @param  None
+ * @retval None
+ */
 void HAL_MspInit(void)
 {
     __HAL_RCC_SYSCFG_CLK_ENABLE();
@@ -633,22 +636,22 @@ void HAL_MspInit(void)
 }
 
 /**
-  * @brief  Debug over UART2 -> ST-LINK -> USB Virtual Com Port
-  * @param  str: string to be written to UART2
-  * @retval None
-  */
+ * @brief  Debug over UART2 -> ST-LINK -> USB Virtual Com Port
+ * @param  str: string to be written to UART2
+ * @retval None
+ */
 void print(const char* str)
 {
-#if (USE_VCP)
+#if(USE_VCP)
     HAL_UART_Transmit(&huart2, (uint8_t*)str, (uint16_t)strlen(str), 100);
 #endif /* USE_VCP */
 }
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @param  None
-  * @retval None
-  */
+ * @brief  This function is executed in case of error occurrence.
+ * @param  None
+ * @retval None
+ */
 void Error_Handler(void)
 {
     while(1)
@@ -664,14 +667,13 @@ void Error_Handler(void)
 
 #ifdef USE_FULL_ASSERT
 /**
-  * @brief  Reports the name of the source file and the source line number
-  *         where the assert_param error has occurred.
-  * @param  file: pointer to the source file name
-  * @param  line: assert_param error line source number
-  * @retval None
-  */
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
 void assert_failed(uint8_t* file, uint32_t line)
 {
-
 }
 #endif

--- a/projects/STM32L496-Discovery/source/sd_diskio.c
+++ b/projects/STM32L496-Discovery/source/sd_diskio.c
@@ -1,23 +1,23 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   sd_diskio.c
-  * @brief  SD diskio driver
-  *	        This file contains the implementation of the SD diskio driver
-  *         used by the FatFs module. The driver uses the HAL library of ST.
-  *
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   sd_diskio.c
+ * @brief  SD diskio driver
+ *	       This file contains the implementation of the SD diskio driver
+ *         used by the FatFs module. The driver uses the HAL library of ST.
+ *
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 #include "ff_gen_drv.h"
 #include "sd_diskio.h"
 
 /* Defines -------------------------------------------------------------------*/
-#define SD_TIMEOUT      SD_DATATIMEOUT      /* Defined in bsp_driver_sd.h */
+#define SD_TIMEOUT SD_DATATIMEOUT /* Defined in bsp_driver_sd.h */
 
 /*
  * Depending on the use case, the SD card initialization could be done at the
@@ -42,38 +42,33 @@
 //#define ENABLE_SD_DMA_CACHE_MAINTENANCE 1
 
 /* Private variables ---------------------------------------------------------*/
-static volatile DSTATUS Stat = STA_NOINIT;      /* Disk status */
-static volatile UINT    ReadStatus = 0;
+static volatile DSTATUS Stat        = STA_NOINIT; /* Disk status */
+static volatile UINT    ReadStatus  = 0;
 static volatile UINT    WriteStatus = 0;
 
 /* Private function prototypes -----------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun);
-DSTATUS SD_initialize (BYTE);
-DSTATUS SD_status (BYTE);
-DRESULT SD_read (BYTE, BYTE*, DWORD, UINT);
+DSTATUS        SD_initialize(BYTE);
+DSTATUS        SD_status(BYTE);
+DRESULT        SD_read(BYTE, BYTE*, DWORD, UINT);
 
 #if _USE_WRITE == 1
-DRESULT SD_write (BYTE, const BYTE*, DWORD, UINT);
+DRESULT SD_write(BYTE, const BYTE*, DWORD, UINT);
 #endif /* _USE_WRITE == 1 */
 
 #if _USE_IOCTL == 1
-DRESULT SD_ioctl (BYTE, BYTE, void*);
-#endif  /* _USE_IOCTL == 1 */
+DRESULT SD_ioctl(BYTE, BYTE, void*);
+#endif /* _USE_IOCTL == 1 */
 
-
-const Diskio_drvTypeDef  SD_Driver =
-{
-    SD_initialize,
-    SD_status,
-    SD_read,
-#if  _USE_WRITE == 1
+const Diskio_drvTypeDef SD_Driver = {
+    SD_initialize, SD_status, SD_read,
+#if _USE_WRITE == 1
     SD_write,
 #endif /* _USE_WRITE == 1 */
-#if  _USE_IOCTL == 1
+#if _USE_IOCTL == 1
     SD_ioctl,
 #endif /* _USE_IOCTL == 1 */
 };
-
 
 /* Private functions ---------------------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun)
@@ -89,10 +84,10 @@ static DSTATUS SD_CheckStatus(BYTE lun)
 }
 
 /**
-  * @brief  Initializes a Drive
-  * @param  lun : not used
-  * @retval DSTATUS: Operation status
-  */
+ * @brief  Initializes a Drive
+ * @param  lun : not used
+ * @retval DSTATUS: Operation status
+ */
 DSTATUS SD_initialize(BYTE lun)
 {
     Stat = STA_NOINIT;
@@ -106,31 +101,31 @@ DSTATUS SD_initialize(BYTE lun)
     Stat = SD_CheckStatus(lun);
 #endif
 
-    ReadStatus = 0;
+    ReadStatus  = 0;
     WriteStatus = 0;
 
     return Stat;
 }
 
 /**
-  * @brief  Gets Disk Status
-  * @param  lun : not used
-  * @retval DSTATUS: Operation status
-  */
+ * @brief  Gets Disk Status
+ * @param  lun : not used
+ * @retval DSTATUS: Operation status
+ */
 DSTATUS SD_status(BYTE lun)
 {
     return SD_CheckStatus(lun);
 }
 
 /**
-  * @brief  Reads Sector(s)
-  * @param  lun : not used
-  * @param  *buff: Data buffer to store read data
-  * @param  sector: Sector address (LBA)
-  * @param  count: Number of sectors to read (1..128)
-  * @retval DRESULT: Operation result
-  */
-DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
+ * @brief  Reads Sector(s)
+ * @param  lun : not used
+ * @param  *buff: Data buffer to store read data
+ * @param  sector: Sector address (LBA)
+ * @param  count: Number of sectors to read (1..128)
+ * @retval DRESULT: Operation result
+ */
+DRESULT SD_read(BYTE lun, BYTE* buff, DWORD sector, UINT count)
 {
     DRESULT  res;
     uint32_t timeout;
@@ -142,10 +137,11 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
     uint32_t alignedAddr;
 #endif /* SD_DMA_CACHE_MAINTENANCE */
 
-    res = RES_ERROR;
+    res        = RES_ERROR;
     ReadStatus = 0;
 
-    if(BSP_SD_ReadBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) == MSD_OK)
+    if(BSP_SD_ReadBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) ==
+       MSD_OK)
     {
         /* Wait for DMA Complete */
         timeout = HAL_GetTick();
@@ -161,18 +157,21 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
         else
         {
             ReadStatus = 0;
-            timeout = HAL_GetTick();
+            timeout    = HAL_GetTick();
             while((HAL_GetTick() - timeout) < SD_TIMEOUT)
             {
                 if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
                 {
                     res = RES_OK;
 #if defined(ENABLE_SD_DMA_CACHE_MAINTENANCE)
-                    /* The SCB_InvalidateDCache_by_Addr() requires a 32-Byte aligned address,
-                     * adjust the address and the D-Cache size to invalidate accordingly.
-                    */
+                    /* The SCB_InvalidateDCache_by_Addr() requires a 32-Byte
+                     * aligned address, adjust the address and the D-Cache size
+                     * to invalidate accordingly.
+                     */
                     alignedAddr = (uint32_t)buff & ~0x1F;
-                    SCB_InvalidateDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+                    SCB_InvalidateDCache_by_Addr(
+                        (uint32_t*)alignedAddr,
+                        count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif /* SD_DMA_CACHE_MAINTENANCE */
                     break;
                 }
@@ -185,9 +184,8 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 #else
     /* Use SD Driver in blocking mode */
     res = RES_ERROR;
-    if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                         (uint32_t)(sector),
-                         count, SDMMC_HAL_TIMEOUT) == MSD_OK)
+    if(BSP_SD_ReadBlocks((uint32_t*)buff, (uint32_t)(sector), count,
+                         SDMMC_HAL_TIMEOUT) == MSD_OK)
     {
         /* Wait until the read operation is finished */
         timeout = HAL_GetTick();
@@ -204,17 +202,16 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 #endif /* ENABLE_SD_DMA_DRIVER */
 }
 
-
 /**
-  * @brief  Writes Sector(s)
-  * @param  lun : not used
-  * @param  *buff: Data to be written
-  * @param  sector: Sector address (LBA)
-  * @param  count: Number of sectors to write (1..128)
-  * @retval DRESULT: Operation result
-  */
+ * @brief  Writes Sector(s)
+ * @param  lun : not used
+ * @param  *buff: Data to be written
+ * @param  sector: Sector address (LBA)
+ * @param  count: Number of sectors to write (1..128)
+ * @retval DRESULT: Operation result
+ */
 #if _USE_WRITE == 1
-DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
+DRESULT SD_write(BYTE lun, const BYTE* buff, DWORD sector, UINT count)
 {
     DRESULT  res;
     uint32_t timeout;
@@ -224,14 +221,16 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 
 #if defined(ENABLE_SD_DMA_CACHE_MAINTENANCE)
     uint32_t alignedAddr;
-    alignedAddr = (uint32_t)buff &  ~0x1F;
-    SCB_CleanDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+    alignedAddr = (uint32_t)buff & ~0x1F;
+    SCB_CleanDCache_by_Addr((uint32_t*)alignedAddr,
+                            count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif
 
-    res = RES_ERROR;
+    res         = RES_ERROR;
     WriteStatus = 0;
 
-    if(BSP_SD_WriteBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) == MSD_OK)
+    if(BSP_SD_WriteBlocks_DMA((uint32_t*)buff, (uint32_t)(sector), count) ==
+       MSD_OK)
     {
         /* Wait for DMA complete */
         timeout = HAL_GetTick();
@@ -247,7 +246,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
         else
         {
             WriteStatus = 0;
-            timeout = HAL_GetTick();
+            timeout     = HAL_GetTick();
             while((HAL_GetTick() - timeout) < SD_TIMEOUT)
             {
                 if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
@@ -264,9 +263,8 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 #else
     /* Use SD Driver in blocking mode */
     res = RES_ERROR;
-    if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                          (uint32_t)(sector),
-                          count, SDMMC_HAL_TIMEOUT) == MSD_OK)
+    if(BSP_SD_WriteBlocks((uint32_t*)buff, (uint32_t)(sector), count,
+                          SDMMC_HAL_TIMEOUT) == MSD_OK)
     {
         /* Wait until the Write operation is finished */
         timeout = HAL_GetTick();
@@ -285,75 +283,74 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 #endif /* _USE_WRITE == 1 */
 
 /**
-  * @brief  I/O control operation
-  * @param  lun : not used
-  * @param  cmd: Control code
-  * @param  *buff: Buffer to send/receive control data
-  * @retval DRESULT: Operation result
-  */
+ * @brief  I/O control operation
+ * @param  lun : not used
+ * @param  cmd: Control code
+ * @param  *buff: Buffer to send/receive control data
+ * @retval DRESULT: Operation result
+ */
 #if _USE_IOCTL == 1
-DRESULT SD_ioctl(BYTE lun, BYTE cmd, void *buff)
+DRESULT SD_ioctl(BYTE lun, BYTE cmd, void* buff)
 {
-  DRESULT res = RES_ERROR;
-  BSP_SD_CardInfo CardInfo;
+    DRESULT         res = RES_ERROR;
+    BSP_SD_CardInfo CardInfo;
 
-  if(Stat & STA_NOINIT)
-  {
-      return RES_NOTRDY;
-  }
+    if(Stat & STA_NOINIT)
+    {
+        return RES_NOTRDY;
+    }
 
-  switch(cmd)
-  {
-      /* Make sure that no pending write process */
-      case CTRL_SYNC :
-        res = RES_OK;
-        break;
+    switch(cmd)
+    {
+        /* Make sure that no pending write process */
+        case CTRL_SYNC:
+            res = RES_OK;
+            break;
 
-      /* Get number of sectors on the disk (DWORD) */
-      case GET_SECTOR_COUNT :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(DWORD*)buff = CardInfo.LogBlockNbr;
-        res = RES_OK;
-        break;
+        /* Get number of sectors on the disk (DWORD) */
+        case GET_SECTOR_COUNT:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(DWORD*)buff = CardInfo.LogBlockNbr;
+            res           = RES_OK;
+            break;
 
-      /* Get R/W sector size (WORD) */
-      case GET_SECTOR_SIZE :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(WORD*)buff = CardInfo.LogBlockSize;
-        res = RES_OK;
-        break;
+        /* Get R/W sector size (WORD) */
+        case GET_SECTOR_SIZE:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(WORD*)buff = CardInfo.LogBlockSize;
+            res          = RES_OK;
+            break;
 
-      /* Get erase block size in unit of sector (DWORD) */
-      case GET_BLOCK_SIZE :
-        BSP_SD_GetCardInfo(&CardInfo);
-        *(DWORD*)buff = CardInfo.LogBlockSize;
-        res = RES_OK;
-        break;
+        /* Get erase block size in unit of sector (DWORD) */
+        case GET_BLOCK_SIZE:
+            BSP_SD_GetCardInfo(&CardInfo);
+            *(DWORD*)buff = CardInfo.LogBlockSize;
+            res           = RES_OK;
+            break;
 
-      default:
-        res = RES_PARERR;
-  }
+        default:
+            res = RES_PARERR;
+    }
 
-  return res;
+    return res;
 }
 #endif /* _USE_IOCTL == 1 */
 
-
 /**
-  * @brief Rx Transfer complete callback
-  * @param hsd: SD handle
-  * @retval None
-  */
+ * @brief Rx Transfer complete callback
+ * @param hsd: SD handle
+ * @retval None
+ */
 void BSP_SD_ReadCpltCallback(void)
 {
     ReadStatus = 1;
 }
 
 /**
-  * @brief Tx Transfer complete callback
-  * @param hsd: SD handle
-  * @retval None
-  */
+ * @brief Tx Transfer complete callback
+ * @param hsd: SD handle
+ * @retval None
+ */
 void BSP_SD_WriteCpltCallback(void)
 {
     WriteStatus = 1;

--- a/projects/STM32L496-Discovery/source/stm32l4xx_it.c
+++ b/projects/STM32L496-Discovery/source/stm32l4xx_it.c
@@ -1,17 +1,17 @@
 /**
-  ******************************************************************************
-  * STM32L4 Bootloader
-  ******************************************************************************
-  * @author Akos Pasztor
-  * @file   stm32l4xx_it.c
-  * @brief  Interrupt Service Routines
-  *	        This file contains the exception and peripheral interrupt handlers.
-  *
-  *
-  ******************************************************************************
-  * @copyright (c) 2019 Akos Pasztor.                   https://akospasztor.com
-  ******************************************************************************
-**/
+ *******************************************************************************
+ * STM32L4 Bootloader
+ *******************************************************************************
+ * @author Akos Pasztor
+ * @file   stm32l4xx_it.c
+ * @brief  Interrupt Service Routines
+ *	       This file contains the exception and peripheral interrupt handlers.
+ *
+ *
+ *******************************************************************************
+ * @copyright (c) 2020 Akos Pasztor.                    https://akospasztor.com
+ *******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32l4xx_hal.h"
@@ -25,16 +25,15 @@ extern SD_HandleTypeDef hsd1;
 /******************************************************************************/
 
 /**
-* @brief This function handles Non maskable interrupt.
-*/
+ * @brief This function handles Non maskable interrupt.
+ */
 void NMI_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Hard fault interrupt.
-*/
+ * @brief This function handles Hard fault interrupt.
+ */
 void HardFault_Handler(void)
 {
     while(1)
@@ -43,8 +42,8 @@ void HardFault_Handler(void)
 }
 
 /**
-* @brief This function handles Memory management fault.
-*/
+ * @brief This function handles Memory management fault.
+ */
 void MemManage_Handler(void)
 {
     while(1)
@@ -53,8 +52,8 @@ void MemManage_Handler(void)
 }
 
 /**
-* @brief This function handles Prefetch fault, memory access fault.
-*/
+ * @brief This function handles Prefetch fault, memory access fault.
+ */
 void BusFault_Handler(void)
 {
     while(1)
@@ -63,8 +62,8 @@ void BusFault_Handler(void)
 }
 
 /**
-* @brief This function handles Undefined instruction or illegal state.
-*/
+ * @brief This function handles Undefined instruction or illegal state.
+ */
 void UsageFault_Handler(void)
 {
     while(1)
@@ -73,32 +72,29 @@ void UsageFault_Handler(void)
 }
 
 /**
-* @brief This function handles System service call via SWI instruction.
-*/
+ * @brief This function handles System service call via SWI instruction.
+ */
 void SVC_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Debug monitor.
-*/
+ * @brief This function handles Debug monitor.
+ */
 void DebugMon_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles Pendable request for system service.
-*/
+ * @brief This function handles Pendable request for system service.
+ */
 void PendSV_Handler(void)
 {
-
 }
 
 /**
-* @brief This function handles System tick timer.
-*/
+ * @brief This function handles System tick timer.
+ */
 void SysTick_Handler(void)
 {
     HAL_IncTick();
@@ -110,9 +106,9 @@ void SysTick_Handler(void)
 /******************************************************************************/
 
 /**
-* @brief DMA2 Channel5 ISR
-* @note  SDMMC DMA Tx, Rx
-*/
+ * @brief DMA2 Channel5 ISR
+ * @note  SDMMC DMA Tx, Rx
+ */
 void DMA2_Channel5_IRQHandler(void)
 {
     if((hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_READ_SINGLE_BLOCK)) ||
@@ -120,16 +116,18 @@ void DMA2_Channel5_IRQHandler(void)
     {
         HAL_DMA_IRQHandler(hsd1.hdmarx);
     }
-    else if((hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_SINGLE_BLOCK)) ||
-            (hsd1.Context == (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_MULTIPLE_BLOCK)))
+    else if((hsd1.Context ==
+             (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_SINGLE_BLOCK)) ||
+            (hsd1.Context ==
+             (SD_CONTEXT_DMA | SD_CONTEXT_WRITE_MULTIPLE_BLOCK)))
     {
         HAL_DMA_IRQHandler(hsd1.hdmatx);
     }
 }
 
 /**
-* @brief SDMMC ISR
-*/
+ * @brief SDMMC ISR
+ */
 void SDMMC1_IRQHandler(void)
 {
     HAL_SD_IRQHandler(&hsd1);

--- a/projects/STM32L496-Discovery/source/system_stm32l4xx.c
+++ b/projects/STM32L496-Discovery/source/system_stm32l4xx.c
@@ -1,353 +1,369 @@
 /**
-  ******************************************************************************
-  * @file    system_stm32l4xx.c
-  * @author  MCD Application Team
-  * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
-  *
-  *   This file provides two functions and one global variable to be called from
-  *   user application:
-  *      - SystemInit(): This function is called at startup just after reset and
-  *                      before branch to main program. This call is made inside
-  *                      the "startup_stm32l4xx.s" file.
-  *
-  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
-  *                                  by the user application to setup the SysTick
-  *                                  timer or configure other parameters.
-  *
-  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
-  *                                 be called whenever the core clock is changed
-  *                                 during program execution.
-  *
-  *   After each device reset the MSI (4 MHz) is used as system clock source.
-  *   Then SystemInit() function is called, in "startup_stm32l4xx.s" file, to
-  *   configure the system clock before to branch to main program.
-  *
-  *   This file configures the system clock as follows:
-  *=============================================================================
-  *-----------------------------------------------------------------------------
-  *        System Clock source                    | MSI
-  *-----------------------------------------------------------------------------
-  *        SYSCLK(Hz)                             | 4000000
-  *-----------------------------------------------------------------------------
-  *        HCLK(Hz)                               | 4000000
-  *-----------------------------------------------------------------------------
-  *        AHB Prescaler                          | 1
-  *-----------------------------------------------------------------------------
-  *        APB1 Prescaler                         | 1
-  *-----------------------------------------------------------------------------
-  *        APB2 Prescaler                         | 1
-  *-----------------------------------------------------------------------------
-  *        PLL_M                                  | 1
-  *-----------------------------------------------------------------------------
-  *        PLL_N                                  | 8
-  *-----------------------------------------------------------------------------
-  *        PLL_P                                  | 7
-  *-----------------------------------------------------------------------------
-  *        PLL_Q                                  | 2
-  *-----------------------------------------------------------------------------
-  *        PLL_R                                  | 2
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_P                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_Q                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI1_R                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_P                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_Q                              | NA
-  *-----------------------------------------------------------------------------
-  *        PLLSAI2_R                              | NA
-  *-----------------------------------------------------------------------------
-  *        Require 48MHz for USB OTG FS,          | Disabled
-  *        SDIO and RNG clock                     |
-  *-----------------------------------------------------------------------------
-  *=============================================================================
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+ *******************************************************************************
+ * @file    system_stm32l4xx.c
+ * @author  MCD Application Team
+ * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File
+ *
+ *   This file provides two functions and one global variable to be called from
+ *   user application:
+ *      - SystemInit(): This function is called at startup just after reset and
+ *                      before branch to main program. This call is made inside
+ *                      the "startup_stm32l4xx.s" file.
+ *
+ *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be
+ *used by the user application to setup the SysTick timer or configure other
+ *parameters.
+ *
+ *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+ *                                 be called whenever the core clock is changed
+ *                                 during program execution.
+ *
+ *   After each device reset the MSI (4 MHz) is used as system clock source.
+ *   Then SystemInit() function is called, in "startup_stm32l4xx.s" file, to
+ *   configure the system clock before to branch to main program.
+ *
+ *   This file configures the system clock as follows:
+ *==============================================================================
+ *------------------------------------------------------------------------------
+ *        System Clock source                    | MSI
+ *------------------------------------------------------------------------------
+ *        SYSCLK(Hz)                             | 4000000
+ *------------------------------------------------------------------------------
+ *        HCLK(Hz)                               | 4000000
+ *------------------------------------------------------------------------------
+ *        AHB Prescaler                          | 1
+ *------------------------------------------------------------------------------
+ *        APB1 Prescaler                         | 1
+ *------------------------------------------------------------------------------
+ *        APB2 Prescaler                         | 1
+ *------------------------------------------------------------------------------
+ *        PLL_M                                  | 1
+ *------------------------------------------------------------------------------
+ *        PLL_N                                  | 8
+ *------------------------------------------------------------------------------
+ *        PLL_P                                  | 7
+ *------------------------------------------------------------------------------
+ *        PLL_Q                                  | 2
+ *------------------------------------------------------------------------------
+ *        PLL_R                                  | 2
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_P                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_Q                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI1_R                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_P                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_Q                              | NA
+ *------------------------------------------------------------------------------
+ *        PLLSAI2_R                              | NA
+ *------------------------------------------------------------------------------
+ *        Require 48MHz for USB OTG FS,          | Disabled
+ *        SDIO and RNG clock                     |
+ *------------------------------------------------------------------------------
+ *==============================================================================
+ *******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *notice, this list of conditions and the following disclaimer in the
+ *documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ *******************************************************************************
+ */
 
 /** @addtogroup CMSIS
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup stm32l4xx_system
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Includes
-  * @{
-  */
+ * @{
+ */
 
 #include "stm32l4xx.h"
 
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    8000000U  /*!< Value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+#if !defined(HSE_VALUE)
+#define HSE_VALUE 8000000U /*!< Value of the External oscillator in Hz */
+#endif                     /* HSE_VALUE */
 
-#if !defined  (MSI_VALUE)
-  #define MSI_VALUE    4000000U  /*!< Value of the Internal oscillator in Hz*/
-#endif /* MSI_VALUE */
+#if !defined(MSI_VALUE)
+#define MSI_VALUE 4000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                     /* MSI_VALUE */
 
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    16000000U /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
+#if !defined(HSI_VALUE)
+#define HSI_VALUE 16000000U /*!< Value of the Internal oscillator in Hz*/
+#endif                      /* HSI_VALUE */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_TypesDefinitions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Defines
-  * @{
-  */
+ * @{
+ */
 
 /************************* Miscellaneous Configuration ************************/
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
-                                   This value must be a multiple of 0x200. */
+#define VECT_TAB_OFFSET                       \
+    0x00 /*!< Vector Table base offset field. \
+              This value must be a multiple of 0x200. */
 /******************************************************************************/
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Macros
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Variables
-  * @{
-  */
-  /* The SystemCoreClock variable is updated in three ways:
-      1) by calling CMSIS function SystemCoreClockUpdate()
-      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
-      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
-         Note: If you use this function to configure the system clock; then there
-               is no need to call the 2 first functions listed above, since SystemCoreClock
-               variable is updated automatically.
-  */
-  uint32_t SystemCoreClock = 4000000U;
+ * @{
+ */
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock
+   frequency Note: If you use this function to configure the system clock; then
+   there is no need to call the 2 first functions listed above, since
+   SystemCoreClock variable is updated automatically.
+*/
+uint32_t SystemCoreClock = 4000000U;
 
-  const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
-  const uint8_t  APBPrescTable[8] =  {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
-  const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,  1000000U,  2000000U, \
-                                      4000000U, 8000000U, 16000000U, 24000000U, 32000000U, 48000000U};
+const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
+                                   1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
+const uint8_t  APBPrescTable[8]  = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
+const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,
+                                    1000000U,  2000000U,  4000000U,  8000000U,
+                                    16000000U, 24000000U, 32000000U, 48000000U};
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_FunctionPrototypes
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup STM32L4xx_System_Private_Functions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @brief  Setup the microcontroller system.
-  * @param  None
-  * @retval None
-  */
+ * @brief  Setup the microcontroller system.
+ * @param  None
+ * @retval None
+ */
 
 void SystemInit(void)
 {
-  /* FPU settings ------------------------------------------------------------*/
-  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
-  #endif
+/* FPU settings ------------------------------------------------------------*/
+#if(__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |=
+        ((3UL << 10 * 2) | (3UL << 11 * 2)); /* set CP10 and CP11 Full Access */
+#endif
 
-  /* Reset the RCC clock configuration to the default reset state ------------*/
-  /* Set MSION bit */
-  RCC->CR |= RCC_CR_MSION;
+    /* Reset the RCC clock configuration to the default reset state
+     * ------------*/
+    /* Set MSION bit */
+    RCC->CR |= RCC_CR_MSION;
 
-  /* Reset CFGR register */
-  RCC->CFGR = 0x00000000U;
+    /* Reset CFGR register */
+    RCC->CFGR = 0x00000000U;
 
-  /* Reset HSEON, CSSON , HSION, and PLLON bits */
-  RCC->CR &= 0xEAF6FFFFU;
+    /* Reset HSEON, CSSON , HSION, and PLLON bits */
+    RCC->CR &= 0xEAF6FFFFU;
 
-  /* Reset PLLCFGR register */
-  RCC->PLLCFGR = 0x00001000U;
+    /* Reset PLLCFGR register */
+    RCC->PLLCFGR = 0x00001000U;
 
-  /* Reset HSEBYP bit */
-  RCC->CR &= 0xFFFBFFFFU;
+    /* Reset HSEBYP bit */
+    RCC->CR &= 0xFFFBFFFFU;
 
-  /* Disable all interrupts */
-  RCC->CIER = 0x00000000U;
+    /* Disable all interrupts */
+    RCC->CIER = 0x00000000U;
 
-  /* Configure the Vector Table location add offset address ------------------*/
+    /* Configure the Vector Table location add offset address
+     * ------------------*/
 #ifdef VECT_TAB_SRAM
-  SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+    SCB->VTOR = SRAM_BASE |
+                VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = FLASH_BASE |
+                VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 }
 
 /**
-  * @brief  Update SystemCoreClock variable according to Clock Register Values.
-  *         The SystemCoreClock variable contains the core clock (HCLK), it can
-  *         be used by the user application to setup the SysTick timer or configure
-  *         other parameters.
-  *
-  * @note   Each time the core clock (HCLK) changes, this function must be called
-  *         to update SystemCoreClock variable value. Otherwise, any configuration
-  *         based on this variable will be incorrect.
-  *
-  * @note   - The system frequency computed by this function is not the real
-  *           frequency in the chip. It is calculated based on the predefined
-  *           constant and the selected clock source:
-  *
-  *           - If SYSCLK source is MSI, SystemCoreClock will contain the MSI_VALUE(*)
-  *
-  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(**)
-  *
-  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(***)
-  *
-  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(***)
-  *             or HSI_VALUE(*) or MSI_VALUE(*) multiplied/divided by the PLL factors.
-  *
-  *         (*) MSI_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *             4 MHz) but the real value may vary depending on the variations
-  *             in voltage and temperature.
-  *
-  *         (**) HSI_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *              16 MHz) but the real value may vary depending on the variations
-  *              in voltage and temperature.
-  *
-  *         (***) HSE_VALUE is a constant defined in stm32l4xx_hal.h file (default value
-  *              8 MHz), user has to ensure that HSE_VALUE is same as the real
-  *              frequency of the crystal used. Otherwise, this function may
-  *              have wrong result.
-  *
-  *         - The result of this function could be not correct when using fractional
-  *           value for HSE crystal.
-  *
-  * @param  None
-  * @retval None
-  */
+ * @brief  Update SystemCoreClock variable according to Clock Register Values.
+ *         The SystemCoreClock variable contains the core clock (HCLK), it can
+ *         be used by the user application to setup the SysTick timer or
+ * configure other parameters.
+ *
+ * @note   Each time the core clock (HCLK) changes, this function must be called
+ *         to update SystemCoreClock variable value. Otherwise, any
+ * configuration based on this variable will be incorrect.
+ *
+ * @note   - The system frequency computed by this function is not the real
+ *           frequency in the chip. It is calculated based on the predefined
+ *           constant and the selected clock source:
+ *
+ *           - If SYSCLK source is MSI, SystemCoreClock will contain the
+ * MSI_VALUE(*)
+ *
+ *           - If SYSCLK source is HSI, SystemCoreClock will contain the
+ * HSI_VALUE(**)
+ *
+ *           - If SYSCLK source is HSE, SystemCoreClock will contain the
+ * HSE_VALUE(***)
+ *
+ *           - If SYSCLK source is PLL, SystemCoreClock will contain the
+ * HSE_VALUE(***) or HSI_VALUE(*) or MSI_VALUE(*) multiplied/divided by the PLL
+ * factors.
+ *
+ *         (*) MSI_VALUE is a constant defined in stm32l4xx_hal.h file (default
+ * value 4 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (**) HSI_VALUE is a constant defined in stm32l4xx_hal.h file (default
+ * value 16 MHz) but the real value may vary depending on the variations in
+ * voltage and temperature.
+ *
+ *         (***) HSE_VALUE is a constant defined in stm32l4xx_hal.h file
+ * (default value 8 MHz), user has to ensure that HSE_VALUE is same as the real
+ *              frequency of the crystal used. Otherwise, this function may
+ *              have wrong result.
+ *
+ *         - The result of this function could be not correct when using
+ * fractional value for HSE crystal.
+ *
+ * @param  None
+ * @retval None
+ */
 void SystemCoreClockUpdate(void)
 {
-  uint32_t tmp = 0U, msirange = 0U, pllvco = 0U, pllr = 2U, pllsource = 0U, pllm = 2U;
+    uint32_t tmp = 0U, msirange = 0U, pllvco = 0U, pllr = 2U, pllsource = 0U,
+             pllm = 2U;
 
-  /* Get MSI Range frequency--------------------------------------------------*/
-  if((RCC->CR & RCC_CR_MSIRGSEL) == RESET)
-  { /* MSISRANGE from RCC_CSR applies */
-    msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> 8U;
-  }
-  else
-  { /* MSIRANGE from RCC_CR applies */
-    msirange = (RCC->CR & RCC_CR_MSIRANGE) >> 4U;
-  }
-  /*MSI frequency range in HZ*/
-  msirange = MSIRangeTable[msirange];
+    /* Get MSI Range
+     * frequency--------------------------------------------------*/
+    if((RCC->CR & RCC_CR_MSIRGSEL) == RESET)
+    { /* MSISRANGE from RCC_CSR applies */
+        msirange = (RCC->CSR & RCC_CSR_MSISRANGE) >> 8U;
+    }
+    else
+    { /* MSIRANGE from RCC_CR applies */
+        msirange = (RCC->CR & RCC_CR_MSIRANGE) >> 4U;
+    }
+    /*MSI frequency range in HZ*/
+    msirange = MSIRangeTable[msirange];
 
-  /* Get SYSCLK source -------------------------------------------------------*/
-  switch (RCC->CFGR & RCC_CFGR_SWS)
-  {
-    case 0x00:  /* MSI used as system clock source */
-      SystemCoreClock = msirange;
-      break;
+    /* Get SYSCLK source
+     * -------------------------------------------------------*/
+    switch(RCC->CFGR & RCC_CFGR_SWS)
+    {
+        case 0x00: /* MSI used as system clock source */
+            SystemCoreClock = msirange;
+            break;
 
-    case 0x04:  /* HSI used as system clock source */
-      SystemCoreClock = HSI_VALUE;
-      break;
+        case 0x04: /* HSI used as system clock source */
+            SystemCoreClock = HSI_VALUE;
+            break;
 
-    case 0x08:  /* HSE used as system clock source */
-      SystemCoreClock = HSE_VALUE;
-      break;
+        case 0x08: /* HSE used as system clock source */
+            SystemCoreClock = HSE_VALUE;
+            break;
 
-    case 0x0C:  /* PLL used as system clock  source */
-      /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
-         SYSCLK = PLL_VCO / PLLR
-         */
-      pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
-      pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4U) + 1U ;
+        case 0x0C: /* PLL used as system clock  source */
+            /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI_VALUE/ PLLM) * PLLN
+               SYSCLK = PLL_VCO / PLLR
+               */
+            pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
+            pllm      = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> 4U) + 1U;
 
-      switch (pllsource)
-      {
-        case 0x02:  /* HSI used as PLL clock source */
-          pllvco = (HSI_VALUE / pllm);
-          break;
+            switch(pllsource)
+            {
+                case 0x02: /* HSI used as PLL clock source */
+                    pllvco = (HSI_VALUE / pllm);
+                    break;
 
-        case 0x03:  /* HSE used as PLL clock source */
-          pllvco = (HSE_VALUE / pllm);
-          break;
+                case 0x03: /* HSE used as PLL clock source */
+                    pllvco = (HSE_VALUE / pllm);
+                    break;
 
-        default:    /* MSI used as PLL clock source */
-          pllvco = (msirange / pllm);
-          break;
-      }
-      pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8U);
-      pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25U) + 1U) * 2U;
-      SystemCoreClock = pllvco/pllr;
-      break;
+                default: /* MSI used as PLL clock source */
+                    pllvco = (msirange / pllm);
+                    break;
+            }
+            pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 8U);
+            pllr   = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> 25U) + 1U) * 2U;
+            SystemCoreClock = pllvco / pllr;
+            break;
 
-    default:
-      SystemCoreClock = msirange;
-      break;
-  }
-  /* Compute HCLK clock frequency --------------------------------------------*/
-  /* Get HCLK prescaler */
-  tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4U)];
-  /* HCLK clock frequency */
-  SystemCoreClock >>= tmp;
+        default:
+            SystemCoreClock = msirange;
+            break;
+    }
+    /* Compute HCLK clock frequency
+     * --------------------------------------------*/
+    /* Get HCLK prescaler */
+    tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4U)];
+    /* HCLK clock frequency */
+    SystemCoreClock >>= tmp;
 }
 
+/**
+ * @}
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
+ * @}
+ */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/python/check_format.py
+++ b/python/check_format.py
@@ -142,7 +142,7 @@ def main():
                 files.add(os.path.relpath(f))
         file_list = list(files)
         error_count, file_errors = check_format(style=args.style,
-                                                      files=file_list)
+                                                files=file_list)
         exit(error_count)
 
     except Exception as e:

--- a/python/check_format.py
+++ b/python/check_format.py
@@ -65,7 +65,7 @@ def errors_from_replacements(file, replacements=[]):
     return errors
 
 
-def clang_format_check(files=[], style="file"):
+def check_format(files=[], style="file"):
     total_error_count = 0
     file_errors = dict()
 
@@ -141,7 +141,7 @@ def main():
             for f in glob.iglob(pattern):
                 files.add(os.path.relpath(f))
         file_list = list(files)
-        error_count, file_errors = clang_format_check(style=args.style,
+        error_count, file_errors = check_format(style=args.style,
                                                       files=file_list)
         exit(error_count)
 

--- a/python/clang_format_check.py
+++ b/python/clang_format_check.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import glob
+import os
+import subprocess
+import traceback
+import xml.etree.ElementTree as ET
+from collections import namedtuple
+
+__author__ = "github.com/cloderic"
+__version__ = "0.3"
+
+# Modifications and python3 compatibility added by:
+# AKOS PASZTOR | github.com/akospasztor | 2020
+
+
+def replacements_from_file(file, style="file"):
+    Replacement = namedtuple("Replacement", "offset length text")
+    replacements = []
+
+    clang_format_args = ["clang-format"]
+    clang_format_args.append("-style={}".format(style))
+    clang_format_args.append("-output-replacements-xml")
+    clang_format_args.append(os.path.basename(file))
+    replacement_xml = subprocess.check_output(clang_format_args,
+                                              cwd=os.path.dirname(file))
+    replacement_xml_root = ET.XML(replacement_xml)
+    for replacement_item in replacement_xml_root.findall('replacement'):
+        replacements.append(Replacement(
+            offset=int(replacement_item.attrib["offset"]),
+            length=int(replacement_item.attrib["length"]),
+            text=replacement_item.text
+        ))
+
+    return replacements
+
+
+def errors_from_replacements(file, replacements=[]):
+    Error = namedtuple("Error", "line column found expected")
+    errors = []
+
+    lines = [0]  # line index to character offset
+    file_content = ""
+    for line in open(file, "r"):
+        file_content += line
+        lines.append(lines[-1] + len(line))
+
+    for line_index, line_offset in enumerate(lines[:-1]):
+        while (len(replacements) > 0 and
+               lines[line_index + 1] > replacements[0].offset):
+            replacement = replacements.pop(0)
+            errors.append(Error(
+                line=line_index,
+                column=replacement.offset - line_offset,
+                found=file_content[replacement.offset:replacement.offset +
+                                   replacement.length],
+                expected=replacement.text if replacement.text else ""
+            ))
+
+        if len(replacements) == 0:
+            break
+
+    return errors
+
+
+def clang_format_check(files=[], style="file"):
+    total_error_count = 0
+    file_errors = dict()
+
+    print("Collected {} files to check.".format(len(files)))
+    for f in files:
+        replacements = replacements_from_file(f, style)
+        errors = errors_from_replacements(f, replacements)
+        if len(errors) > 0:
+            print("- Checking {} ... {} format error(s)"
+                  .format(f, len(errors)))
+        else:
+            print("- Checking {} ... ok".format(f))
+        total_error_count += len(errors)
+        file_errors[f] = errors
+    if total_error_count == 0:
+        print("No format errors found.")
+    else:
+        print("A total of {} format error(s) were found."
+              .format(total_error_count))
+    return total_error_count, file_errors
+
+
+def check_clang_format_exec():
+    try:
+        subprocess.check_output(["clang-format", "-version"])
+        return True
+    except subprocess.CalledProcessError:
+        # it seems that in some version of clang-format '-version' leads to
+        # non-zero exist status
+        return True
+    except OSError:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="C/C++ formatting check using clang-format")
+
+    # Style
+    parser.add_argument("-s", "--style",
+                        default="file",
+                        help="Coding style, pass-through to clang-format's "
+                        "-style=<string>, (default is '%(default)s').")
+
+    # Exit cleanly on missing clang-format
+    parser.add_argument("--success-on-missing-clang-format",
+                        action="store_true",
+                        help="If set this flag will lead to a success (zero "
+                        "exit status) if clang-format is not available.")
+
+    # Files or directory to check
+    parser.add_argument("file", nargs="+", help="Paths to the files that will "
+                        "be checked (wilcards accepted).")
+    args = parser.parse_args()
+
+    try:
+        # Adding the double quotes around the inline style
+        if len(args.style) > 0 and args.style[0] == "{":
+            args.style = "\"" + args.style + "\""
+
+        # Checking that clang-format is available
+        if not check_clang_format_exec():
+            print("Can't run 'clang-format', please make sure it is installed "
+                  "and reachable in your PATH.")
+            if args.success_on_missing_clang_format:
+                exit(0)
+            else:
+                exit(-1)
+
+        # Globing the file paths
+        files = set()
+        for pattern in args.file:
+            for f in glob.iglob(pattern):
+                files.add(os.path.relpath(f))
+        file_list = list(files)
+        error_count, file_errors = clang_format_check(style=args.style,
+                                                      files=file_list)
+        exit(error_count)
+
+    except Exception as e:
+        print("Exception raised:")
+        print("    " + str(e))
+        print('-' * 79)
+        traceback.print_exc()
+        print('-' * 79)
+        exit(-2)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/clang_format_run.py
+++ b/python/clang_format_run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import subprocess
+from common import collect_source_files
+
+
+def clang_format_run(source, style="file"):
+    for s in source:
+        clang_format_args = ["clang-format"]
+        clang_format_args.append("-style={}".format(style))
+        clang_format_args.append("-i")
+        clang_format_args.append(os.path.basename(s))
+        print("Formatting {}".format(s))
+        output = subprocess.check_output(clang_format_args,
+                                         cwd=os.path.dirname(s))
+        if len(output) > 0:
+            print(output)
+
+
+if __name__ == "__main__":
+    file_list = collect_source_files()
+    clang_format_run(file_list)

--- a/python/common.py
+++ b/python/common.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+
+def collect_source_files():
+    # Source files extensions
+    source_pattern = (".c", ".h", ".cpp", ".hpp")
+
+    # Souce files, relative to project path
+    source_list = ["lib/stm32-bootloader/",
+                   "projects/"]
+
+    # This module resides one folder down delative to project path, thus
+    # the source list needs to be adjusted accordingly.
+    source_list = [os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                os.path.normpath(s))
+                   for s in source_list]
+
+    file_list = []
+    for s in source_list:
+        for root, dirs, files in os.walk(s):
+            for f in files:
+                if f.endswith(source_pattern):
+                    file_list.append(os.path.join(root, f))
+    return file_list

--- a/python/run_format.py
+++ b/python/run_format.py
@@ -5,7 +5,7 @@ import subprocess
 from common import collect_source_files
 
 
-def clang_format_run(source, style="file"):
+def run_format(source, style="file"):
     for s in source:
         clang_format_args = ["clang-format"]
         clang_format_args.append("-style={}".format(style))
@@ -20,4 +20,4 @@ def clang_format_run(source, style="file"):
 
 if __name__ == "__main__":
     file_list = collect_source_files()
-    clang_format_run(file_list)
+    run_format(file_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+wheel
+flake8
+pytest~=3.9.0

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from python.common import collect_source_files
+from python.clang_format_check import clang_format_check
+
+
+def test_clang_format():
+    error_count, file_errors = clang_format_check(files=collect_source_files())
+    assert error_count == 0

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from python.common import collect_source_files
-from python.clang_format_check import clang_format_check
+from python.check_format import check_format
 
 
 def test_clang_format():
-    error_count, file_errors = clang_format_check(files=collect_source_files())
+    error_count, file_errors = check_format(files=collect_source_files())
     assert error_count == 0


### PR DESCRIPTION
## Overview
This PR introduces the support for formatting the source code with clang-format.
Additionally, python helper scripts are added for ease-of-use. 

## How to use
- Install LLVM version >= 9.0.1
- Make sure `clang-format` is available from the command line (add the `bin` directory to the path).
- Install the required python packages (see requirements.txt). Note: Recommended use is from a virtualenv. `pip install -r requirements.txt`
- Run the `run_format.py` file located in the python folder to format all source files.
- To check formatting of the entire repository, simply run `pytest tests\test_format.py`.
- Individual files can be checked with the `check_format.py` script.

## Related issues
Closes #21.
