### PR TITLE
Add possibility to provide explicit path for clang-format

### DIFF
--- a/python/run_format.py
+++ b/python/run_format.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argparse
 import os
 import subprocess
 from common import collect_source_files
 
 
-def run_format(source, style="file"):
+def run_format(source, style="file", executable="clang-format"):
+    # Normalize executable path
+    executable = os.path.normpath(executable)
+
     for s in source:
-        clang_format_args = ["clang-format"]
+        clang_format_args = [executable]
         clang_format_args.append("-style={}".format(style))
         clang_format_args.append("-i")
         clang_format_args.append(os.path.basename(s))
@@ -19,5 +23,20 @@ def run_format(source, style="file"):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="C/C++ formatting check using clang-format")
+
+    # Style
+    parser.add_argument("-s", "--style",
+                        default="file",
+                        help="Coding style, pass-through to clang-format's "
+                        "-style=<string>, (default is '%(default)s').")
+
+    # Specify executable for clang-format
+    parser.add_argument("-e", "--executable",
+                        default="clang-format",
+                        help="Path of clang-format (if it's not added to PATH")
+    args = parser.parse_args()
+
     file_list = collect_source_files()
-    run_format(file_list)
+    run_format(file_list, style=args.style, executable=args.executable)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--executable", action="store", default="clang-format",
+        help="Path of clang-format if it's not added to PATH"
+    )
+
+
+@pytest.fixture
+def clang_format_executable(request):
+    return request.config.getoption("--executable")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -4,6 +4,7 @@ from python.common import collect_source_files
 from python.check_format import check_format
 
 
-def test_clang_format():
-    error_count, file_errors = check_format(files=collect_source_files())
+def test_clang_format(clang_format_executable):
+    error_count, file_errors = check_format(files=collect_source_files(),
+                                            executable=clang_format_executable)
     assert error_count == 0


### PR DESCRIPTION
Tests and scripts that run `clang-format` need to have a command line option with the user can specify the exact executable of `clang-format`.

Reasons:
- Multiple clang versions can exist on the system
- Clang-format does not exist in PATH

If no command line argument is specified, the default `clang-format` is used.

Closes #26.