### PR TITLE
Fix a boundary case in CheckForApplication function

### DIFF
--- a/lib/stm32-bootloader/bootloader.c
+++ b/lib/stm32-bootloader/bootloader.c
@@ -394,8 +394,8 @@ uint8_t Bootloader_VerifyChecksum(void)
  */
 uint8_t Bootloader_CheckForApplication(void)
 {
-    return (((*(uint32_t*)APP_ADDRESS) - RAM_BASE) < RAM_SIZE) ? BL_OK
-                                                               : BL_NO_APP;
+    return (((*(uint32_t*)APP_ADDRESS) - RAM_BASE) <= RAM_SIZE) ? BL_OK
+                                                                : BL_NO_APP;
 }
 
 /**


### PR DESCRIPTION
This PR fixes the boundary in `Bootloader_CheckForApplication` function when the stack pointer location is set to the upper bound of the RAM.

Closes #6 