### PR TITLE
Add support for building the project examples with scons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/EWARM/**/List/
 **/EWARM/**/Obj/
 **/GCC/build/
+.sconsign.dblite

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Customizable Bootloader for STM32 microcontrollers. This project includes demons
 
 Each example uses the same bootloader library located in the `lib/stm32-bootloader` folder. The examples are located in the `projects` folder and they come with a separate, dedicated README file with description related to that specific implementation.
 
-Update: the `STM32L496-Discovery` example supports compiling and building the project with the GNU Arm Embedded Toolchain (ARM GCC) out-of-the-box, in addition to IAR EWARM. Check out the project README for further information.
+**Update:** the `STM32L496-Discovery` example supports compiling and building the project with the GNU Arm Embedded Toolchain (ARM GCC) out-of-the-box, in addition to IAR EWARM. Check out the project README for further information.
 
 Please refer to <https://akospasztor.github.io/stm32-bootloader> for complete documentation of the bootloader library source code.
 

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,49 @@
+import os
+
+# Add the required toolchains to the path
+os.environ["PATH"] += os.pathsep + r'C:/Program Files (x86)/GNU Tools ARM Embedded/8 2019-q3-update/bin'
+
+# Command line options
+AddOption('--all',
+          dest='build_config',
+          action='store_const',
+          const='all',
+          help='Build both debug and release configurations',
+)
+AddOption('--release',
+          dest='build_config',
+          action='store_const',
+          const='release',
+          help='Build the release configuration',
+)
+AddOption('--verbose',
+          dest='verbose',
+          action='store_true',
+          help='Print detailed output of actions',
+)
+
+# Build configurations
+configurations = [
+    {
+        'name': 'debug',
+        'optimization_flags': [
+            '-Og',
+            '-g',
+        ],
+    },
+    {
+        'name': 'release',
+        'optimization_flags': [
+            '-O2',
+        ],
+    },
+]
+
+# Get selected configuration (if not specified, defaults to debug)
+selected_config = GetOption('build_config') or 'debug'
+
+# Build configuration
+for build_config in configurations:
+    if selected_config == build_config['name'] or selected_config == 'all':
+        SConscript('projects/STM32L496-Discovery/GCC/SConscript',
+                   exports=['build_config'])

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pool:
 stages:
   - stage: Build
     jobs:
-      - job: stm32l496_discovery
+      - job: stm32l496_discovery_gcc_make
         steps:
           - script: |
               mkdir build
@@ -18,7 +18,28 @@ stages:
               export GCC_PATH=$(pwd)/build/gcc-arm-none-eabi-8-2019-q3-update/bin
               cd projects/STM32L496-Discovery/GCC/
               make
-            displayName: Build project
+            displayName: Build project with Make
+      - job: stm32l496_discovery_gcc_scons
+        steps:
+          - task: UsePythonVersion@0
+            displayName: Select python version 3.7
+            inputs:
+              versionSpec: '3.7'
+          - script: |
+              python -m pip install --upgrade pip
+              pip install -r requirements.txt
+            displayName: Install python dependencies
+          - script: |
+              mkdir build
+              cd build
+              wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+              tar xjf gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+            displayName: Install gcc
+          - script: |
+              export PATH=$PATH:$(pwd)/build/gcc-arm-none-eabi-8-2019-q3-update/bin
+              echo $PATH
+              scons build --all -j8
+            displayName: Build project with SCons
       - job: doxygen
         steps:
           - script: sudo apt-get install doxygen
@@ -34,7 +55,7 @@ stages:
       - job: format_check
         steps:
           - task: UsePythonVersion@0
-            displayName: Select python version
+            displayName: Select python version 3.7
             inputs:
               versionSpec: '3.7'
           - script: |

--- a/projects/STM32L496-Discovery/GCC/SConscript
+++ b/projects/STM32L496-Discovery/GCC/SConscript
@@ -1,0 +1,182 @@
+import os
+
+# Import build configuration
+Import('build_config')
+
+# Get project path: this is the path of the SConscript file
+project_path = Dir('#').rel_path(Dir('.'))
+
+# >>> Project Configuration ---------------------------------------------------
+
+# Specify the build directory and its subfolders
+build_dir = os.path.join('build', build_config['name'])
+obj_subdir = 'obj'
+
+# Specify the target outputs
+target_name = 'stm32-bootloader'
+target_exe = os.path.join(build_dir, target_name)
+target_hex = os.path.join(build_dir, target_name) + '.hex'
+target_bin = os.path.join(build_dir, target_name) + '.bin'
+
+# Microcontroller flags
+mcu_flags = [
+    '-mcpu=cortex-m4',
+    '-mthumb',
+    '-mfpu=fpv4-sp-d16',
+    '-mfloat-abi=hard',
+]
+
+# Common compiler flags
+common_flags = [
+    '-Wall',
+    '-pedantic',
+    '-fdata-sections',
+    '-ffunction-sections',
+]
+
+# Assembler flags
+a_flags = [
+    '-c',
+]
+
+# C/C++ compiler flags
+cc_flags = [
+    '-MMD',
+    '-MP',
+]
+
+# Linker flags
+link_flags = [
+    '-T{}'.format(os.path.join(project_path, 'stm32l496xx_flash.ld')),
+    '-specs=nano.specs',
+    '-specs=nosys.specs',
+    '-lc',
+    '-lm',
+    '-lnosys',
+    '-Wl,-Map={}.map,--cref'.format(os.path.join(project_path, target_exe)),
+    '-Wl,--gc-sections',
+]
+
+# Defines
+defines = [
+    'USE_HAL_DRIVER',
+    'STM32L496xx',
+]
+
+# Include locations
+includes = [
+    '../include',
+    '#/lib/stm32-bootloader',
+    '#/lib/fatfs',
+    '#/drivers/CMSIS/Include',
+    '#/drivers/CMSIS/Device/ST/STM32L4xx/Include',
+    '#/drivers/STM32L4xx_HAL_Driver/Inc',
+]
+
+# Source files
+sources = Glob('#/lib/stm32-bootloader/*.c')
+sources += Glob('#/lib/fatfs/*.c')
+sources += Glob('#/drivers/STM32L4xx_HAL_Driver/Src/*.c')
+sources += Glob('#/lib/fatfs/option/unicode.c')
+sources += Glob('../source/*.c')
+sources += Glob('startup_stm32l496xx.s')
+
+# <<< End of configuration ----------------------------------------------------
+
+# Create environment
+env = Environment(
+    ENV={'PATH': os.environ['PATH']}
+)
+
+# Specify the cross compiler toolchain
+cross_compiler = 'arm-none-eabi-'
+for (tool, name) in [
+    ('AS', 'gcc -x assembler-with-cpp'),
+    ('CC', 'gcc'),
+    ('CXX', 'g++'),
+    ('LINK', 'g++'),
+    ('OBJCOPY', 'objcopy'),
+    ('SIZE', 'size'),
+]:
+    env[tool] = cross_compiler + name
+
+# Overwrite the default assembler command variables
+env['ASCOMSTR'] = 'Assembling static object $TARGET'
+
+# Overwrite the default compiler command variables
+env['CCCOMSTR'] = 'Compiling static object $TARGET'
+
+# Overwrite the default linker command variables
+env['LINKCOM'] = '$LINK $LINKFLAGS -o $TARGET $SOURCES'
+env['LINKCOMSTR'] = 'Linking $TARGET'
+
+# Overwrite the default objcopy command string
+env['OBJCOPYCOMSTR'] = 'Generating $TARGET'
+
+# Overwrite the default size command string
+env['SIZECOMSTR'] = 'Generating size information'
+
+# Clear all COMSTR variables if verbose mode is requested
+if GetOption('verbose'):
+    for key, value in env.items():
+        if key.endswith('COMSTR'):
+            env[key] = ''
+
+# Set the executable file suffix
+env['PROGSUFFIX'] = ".elf"
+
+# Set the object file suffix
+env['OBJSUFFIX'] = ".o"
+
+# Set the assembler flags
+env['ASFLAGS'] = a_flags + mcu_flags + common_flags + build_config['optimization_flags']
+
+# Set the C/C++ compiler flags
+env['CCFLAGS'] = cc_flags + mcu_flags + common_flags + build_config['optimization_flags']
+
+# Set the linker flags
+env['LINKFLAGS'] = mcu_flags + link_flags
+
+# Set the defines
+env['CPPDEFINES'] = defines
+
+# Set the include locations
+env['CPPPATH'] = includes
+
+# Build object files
+obj_list = []
+for src in sources:
+    filename = (os.path.splitext(os.path.basename(str(src)))[0])
+    obj = os.path.join(build_dir, obj_subdir, (filename + '.o'))
+    extra_flags = [
+        '-Wa,-a,-ad,-alms={}.lst'.format(
+            os.path.join(project_path, build_dir, obj_subdir, filename)),
+    ]
+    env.Object(target=obj, source=src, CCFLAGS=(env['CCFLAGS'] + extra_flags))
+    obj_list.append(obj)
+
+# Build executable
+program = env.Program(target_exe, obj_list)
+
+# Create hex output
+hexfile = env.Command(target_hex, program, Action(
+    '$OBJCOPY -O ihex $SOURCE $TARGET', env['OBJCOPYCOMSTR']))
+
+# Create binary output
+binary = env.Command(target_bin, program, Action(
+    '$OBJCOPY -O binary -S $SOURCE $TARGET', env['OBJCOPYCOMSTR']))
+
+# Generate size information
+size = env.Command(None, program, Action('$SIZE $SOURCE', env['SIZECOMSTR']))
+
+# Define build targets
+build_targets = [program, hexfile, binary, size]
+
+# Specify additional files and directories that should be removed during clean
+env.Clean(build_targets, 'build')
+
+# Define default target
+env.Default(build_targets)
+
+# Define target aliases
+env.Alias('build', build_targets)

--- a/projects/STM32L496-Discovery/README.md
+++ b/projects/STM32L496-Discovery/README.md
@@ -57,7 +57,9 @@ After power-up, the bootloader starts. The bootloader checks for user-interactio
 *Figure 3: Bootloader sequence*
 
 ## Compile & Build
-The project can be built out-of-the-box with either IAR EWARM or GNU Arm Embedded Toolchain. The `EWARM` subfolder contains the required files to compile and build the demo with the IAR EWARM toolchain. The `GCC` subfolder contains the compiler-specific files as well as a makefile to easily compile and build the project with the GNU Arm Embedded Toolchain.
+The project can be built out-of-the-box with either IAR EWARM or GNU Arm Embedded Toolchain. The `EWARM` subfolder contains the required files to compile and build the demo with the IAR EWARM toolchain.
+
+The `GCC` subfolder contains the compiler-specific files, a `Makefile` and a `SConscript` file to easily compile and build the project with the GNU Arm Embedded Toolchain.
 
 ### IAR EWARM
 1. Open the `Project.eww` workspace file with IAR.
@@ -68,13 +70,27 @@ Note: The IAR EWARM project is already configured with the required parameters a
 ### GNU Arm Embedded Toolchain
 Prerequisites:
 - GNU Arm Embedded Toolchain, recommended version: 8-2019-q3-update
-- GNU Make (for Windows, see: [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm))
+- At least one of the followings:
+    - GNU Make (for Windows, see: [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm))
+    - Python with pip
 
-Steps to compile and build:
+#### Build with Make
+Steps to compile and build with GNU Make:
+
 1. If the GNU Arm Embedded Toolchain has not been added to PATH: Edit the `CUSTOMPATH` variable in the `Makefile` so that it points to the `bin` folder of the installed GNU Arm Embedded Toolchain.
 2. Open up your favorite terminal and navigate to the `GCC` subfolder where the makefile is located.
 3. Type `make` and hit enter.
 4. The `build` subfolder should contain the binary, ELF and HEX output files, named `stm32-bootloader.bin`, `stm32-bootloader.elf` and `stm32-bootloader.hex` respectively.
+
+#### Build with SCons
+This project currently supports two build configurations: debug (default) and release. Follow these steps to compile and build the project with SCons. Please note that the recommended usage is within a virtualenv.
+
+1. Install the requirements: `pip install -r requirements.txt`
+2. If the `bin` folder of the GNU Arm Embedded Toolchain does not exist in the PATH, it can be specified in the `SConstruct` file.
+3. To build the project with the default debug configuration, execute: `scons -j8`
+4. To build all build configurations at once, execute: `scons --all -j8`
+5. To list all supported arguments, execute: `scons --help`
+6. The `build` subfolder should contain the generated outputs, organized in subfolders with the names of the build configurations.
 
 ## References
 [1] 32L496GDISCOVERY, https://www.st.com/en/evaluation-tools/32l496gdiscovery.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ wheel
 flake8~=3.8.4
 pytest~=3.9.0
 yamllint~=1.25.0
+scons~=4.0.1


### PR DESCRIPTION
## Description

This PR adds the support for building the project examples with scons. 

Note: Currently the STM32L496-Discovery project can be built with GCC via scons.

## Requirements
- Python installation
- GNU Arm Embedded Toolchain

## Usage 
Note: it is recommended to execute the steps from a virtualenv.

1. Install the requirements: `pip install -r requirements.txt`
2. If the `bin` folder of the GNU Arm Embedded Toolchain does not exist in the `PATH`, then edit the `SConstruct` file and specify it there.
3. To build the project, execute: `scons build -j8`
4. To list all supported arguments, execute: `scons --help`

## Related Issues
Closes #39.
