### PR TITLE
Obtain number of pages from registers

### DIFF
--- a/lib/stm32-bootloader/bootloader.h
+++ b/lib/stm32-bootloader/bootloader.h
@@ -71,7 +71,7 @@
 #define APP_SIZE (uint32_t)(((END_ADDRESS - APP_ADDRESS) + 3) / 4)
 
 /** Number of pages per bank in flash */
-#define FLASH_PAGE_NBPERBANK (256)
+#define FLASH_PAGE_NBPERBANK (FLASH_SIZE / FLASH_PAGE_SIZE)
 
 /* MCU RAM information (to check whether flash contains valid application) */
 #define RAM_BASE SRAM1_BASE     /*!< Start address of RAM */


### PR DESCRIPTION
I run into an issue were we had to use the same micros with different flash sizes. Reading the flash size from memory meant we could reuse the bootloader for any of them.

Is there a reason why this is not done like this?